### PR TITLE
refactor: simplify sidebar active state

### DIFF
--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -13,7 +13,7 @@ import {
   Shield,
   Package
 } from "lucide-react"
-import { NavLink, useLocation } from "react-router-dom"
+import { NavLink } from "react-router-dom"
 import { useIsMobile } from "@/hooks/use-mobile"
 import { useRole } from "@/hooks/useRole"
 
@@ -82,18 +82,15 @@ const getMenuItems = (role: string | null) => {
 export function AppSidebar() {
   const { state } = useSidebar()
   const isMobile = useIsMobile()
-  const location = useLocation()
   const { role } = useRole()
-  const currentPath = location.pathname
   const isCollapsed = state === "collapsed"
   
   const { mainItems, businessItems } = getMenuItems(role);
 
-  const isActive = (path: string) => currentPath === path
   const getNavCls = ({ isActive }: { isActive: boolean }) =>
     `transition-all duration-200 hover-scale ${
-      isActive 
-        ? "bg-sidebar-accent text-sidebar-accent-foreground font-medium animate-scale-in" 
+      isActive
+        ? "bg-sidebar-accent text-sidebar-accent-foreground font-medium animate-scale-in"
         : "hover:bg-sidebar-accent/50"
     }`
 


### PR DESCRIPTION
## Summary
- remove custom `isActive` helper and `useLocation` import from `AppSidebar`
- rely solely on `NavLink`'s `isActive` prop for active link styling

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 25 problems (13 errors, 12 warnings))*
- `npx eslint src/components/AppSidebar.tsx && echo "eslint passed"`

------
https://chatgpt.com/codex/tasks/task_e_688e36d2b5c08323980b999b75aead92