### PR TITLE
feat: add accessible labels to header buttons

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -45,9 +45,11 @@ export function Layout({ children }: LayoutProps) {
                 <>
                   <Button variant="ghost" size="icon" className="hover-scale">
                     <Bell className="h-4 w-4 md:h-5 md:w-5" />
+                    <span className="sr-only">Notifications</span>
                   </Button>
                   <Button variant="ghost" size="icon" className="hover-scale">
                     <Settings className="h-4 w-4 md:h-5 md:w-5" />
+                    <span className="sr-only">Settings</span>
                   </Button>
                 </>
               )}


### PR DESCRIPTION
## Summary
- add screen reader text for notification and settings buttons in the layout header

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any. Specify a different type)*

------
https://chatgpt.com/codex/tasks/task_e_688e36ccbadc8323a999172f809b07ca