### PR TITLE
Add Vitest testing setup with sample test

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
     "preview": "vite preview",
-    "start:server": "node server/app.js"
+    "start:server": "node server/app.js",
+    "test": "vitest"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",
@@ -85,6 +86,7 @@
     "tailwindcss": "^3.4.11",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
-    "vite": "^5.4.1"
+    "vite": "^5.4.1",
+    "vitest": "^1.6.0"
   }
 }

--- a/tests/basic.test.ts
+++ b/tests/basic.test.ts
@@ -1,0 +1,8 @@
+import { describe, it, expect } from "vitest"
+
+describe("basic math", () => {
+  it("adds numbers", () => {
+    expect(1 + 1).toBe(2)
+  })
+})
+


### PR DESCRIPTION
## Summary
- add Vitest to dev dependencies and test script
- create basic test verifying addition

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e4566841483239444aeba6526de8c