### PR TITLE
Add Stripe checkout session and webhook handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,7 @@ VITE_OPENAI_API_KEY="sk-your-openai-api-key"
 # Payment Processing (Stripe)
 STRIPE_PUBLISHABLE_KEY="pk_test_your-stripe-publishable-key"
 STRIPE_SECRET_KEY="sk_test_your-stripe-secret-key"
+STRIPE_WEBHOOK_SECRET="whsec_your-stripe-webhook-secret"
 
 # ==================== PRODUCTION DEPLOYMENT ====================
 # For production hosting (Netlify, Vercel, etc.)

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,6 +61,7 @@
         "react-router-dom": "^6.26.2",
         "recharts": "^2.12.7",
         "sonner": "^1.5.0",
+        "stripe": "^14.25.0",
         "tailwind-merge": "^2.5.2",
         "tailwindcss-animate": "^1.0.7",
         "vaul": "^0.9.3",
@@ -8328,6 +8329,19 @@
       "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/stripe": {
+      "version": "14.25.0",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-14.25.0.tgz",
+      "integrity": "sha512-wQS3GNMofCXwH8TSje8E1SE8zr6ODiGtHQgPtO95p9Mb4FhKC9jvXR2NUTpZ9ZINlckJcFidCmaTFV4P6vsb9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=8.1.0",
+        "qs": "^6.11.0"
+      },
+      "engines": {
+        "node": ">=12.*"
+      }
     },
     "node_modules/sucrase": {
       "version": "3.35.0",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "react-router-dom": "^6.26.2",
     "recharts": "^2.12.7",
     "sonner": "^1.5.0",
+    "stripe": "^14.25.0",
     "tailwind-merge": "^2.5.2",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^0.9.3",

--- a/server/app.js
+++ b/server/app.js
@@ -4,6 +4,7 @@ const { createClient } = require('@supabase/supabase-js');
 const { z } = require('zod');
 require('dotenv').config();
 const { syncLead } = require('./hubspot');
+const paymentRoutes = require('./payments');
 
 const app = express();
 const port = process.env.PORT || 4000;
@@ -34,6 +35,8 @@ app.use(
     origin: process.env.CLIENT_ORIGIN || '*',
   })
 );
+
+app.use('/api/payments', paymentRoutes);
 
 // simple health check
 app.get('/api/health', (_req, res) => {

--- a/server/payments.js
+++ b/server/payments.js
@@ -1,0 +1,62 @@
+const express = require('express');
+const Stripe = require('stripe');
+const { createClient } = require('@supabase/supabase-js');
+
+const router = express.Router();
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY || '', {
+  apiVersion: '2022-11-15',
+});
+
+const supabase = createClient(
+  process.env.SUPABASE_URL || '',
+  process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_ROLE || ''
+);
+
+router.post('/checkout', async (req, res) => {
+  try {
+    const { lead_id, lawyer_id, amount, deposit_type, payment_method } = req.body;
+
+    const { data: deposit, error } = await supabase
+      .from('deposits')
+      .insert({
+        lead_id,
+        lawyer_id,
+        amount,
+        deposit_type,
+        payment_method,
+        status: 'pending',
+      })
+      .select()
+      .single();
+
+    if (error) {
+      return res.status(400).json({ error: error.message });
+    }
+
+    const session = await stripe.checkout.sessions.create({
+      payment_method_types: ['card'],
+      line_items: [
+        {
+          price_data: {
+            currency: 'usd',
+            product_data: { name: 'Deposit' },
+            unit_amount: Math.round(amount * 100),
+          },
+          quantity: 1,
+        },
+      ],
+      mode: 'payment',
+      success_url: `${process.env.CLIENT_ORIGIN}/success`,
+      cancel_url: `${process.env.CLIENT_ORIGIN}/cancel`,
+      metadata: { deposit_id: deposit.id },
+    });
+
+    res.json({ url: session.url });
+  } catch (err) {
+    console.error('Stripe checkout error', err);
+    res.status(500).json({ error: 'Unable to create checkout session' });
+  }
+});
+
+module.exports = router;

--- a/src/components/CreateDepositDialog.tsx
+++ b/src/components/CreateDepositDialog.tsx
@@ -5,7 +5,6 @@ import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
 import { Plus, CreditCard } from 'lucide-react';
-import { useDeposits } from '@/hooks/usePayments';
 import { useToast } from '@/hooks/use-toast';
 
 export function CreateDepositDialog() {
@@ -18,7 +17,6 @@ export function CreateDepositDialog() {
     payment_method: 'bit'
   });
 
-  const { addDeposit } = useDeposits();
   const { toast } = useToast();
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -34,23 +32,21 @@ export function CreateDepositDialog() {
     }
 
     try {
-      await addDeposit.mutateAsync({
-        lead_id: depositData.lead_id,
-        lawyer_id: depositData.lawyer_id,
-        amount: parseFloat(depositData.amount),
-        deposit_type: depositData.deposit_type,
-        payment_method: depositData.payment_method,
-        status: 'pending'
+      const res = await fetch('/api/payments/checkout', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          lead_id: depositData.lead_id,
+          lawyer_id: depositData.lawyer_id,
+          amount: parseFloat(depositData.amount),
+          deposit_type: depositData.deposit_type,
+          payment_method: depositData.payment_method,
+        }),
       });
-
-      setDepositData({
-        lead_id: '',
-        lawyer_id: '',
-        amount: '',
-        deposit_type: 'consultation',
-        payment_method: 'bit'
-      });
-      setIsOpen(false);
+      const data = await res.json();
+      if (data.url) {
+        window.location.href = data.url;
+      }
     } catch (error) {
       console.error('Error creating deposit:', error);
     }
@@ -153,12 +149,11 @@ export function CreateDepositDialog() {
             >
               ביטול
             </Button>
-            <Button 
-              type="submit" 
-              disabled={addDeposit.isPending}
+            <Button
+              type="submit"
               className="flex-1"
             >
-              {addDeposit.isPending ? 'שומר...' : 'שמור פיקדון'}
+              {'שמור פיקדון'}
             </Button>
           </div>
         </form>

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -42,3 +42,6 @@ verify_jwt = false
 
 [functions.automated-lead-pipeline]
 verify_jwt = false
+
+[functions.stripe-webhook]
+verify_jwt = false

--- a/supabase/functions/stripe-webhook/index.ts
+++ b/supabase/functions/stripe-webhook/index.ts
@@ -1,0 +1,49 @@
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import Stripe from "https://esm.sh/stripe@14?dts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+};
+
+const stripe = new Stripe(Deno.env.get('STRIPE_SECRET_KEY') ?? '', {
+  apiVersion: '2022-11-15',
+});
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  const body = await req.text();
+  const signature = req.headers.get('stripe-signature') ?? '';
+
+  let event;
+  try {
+    event = stripe.webhooks.constructEvent(body, signature, Deno.env.get('STRIPE_WEBHOOK_SECRET') ?? '');
+  } catch (err) {
+    return new Response(`Webhook Error: ${err.message}`, { status: 400 });
+  }
+
+  if (event.type === 'checkout.session.completed') {
+    const session: any = event.data.object;
+    const depositId = session.metadata?.deposit_id;
+    const paymentIntent = session.payment_intent as string;
+
+    if (depositId) {
+      const supabase = createClient(
+        Deno.env.get('SUPABASE_URL') ?? '',
+        Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? ''
+      );
+      await supabase
+        .from('deposits')
+        .update({ status: 'completed', transaction_id: paymentIntent, paid_at: new Date().toISOString() })
+        .eq('id', depositId);
+    }
+  }
+
+  return new Response(JSON.stringify({ received: true }), {
+    headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+  });
+});


### PR DESCRIPTION
Summary
- add server route for creating Stripe checkout sessions and storing pending deposits
- add edge function to finalize deposits when checkout completes
- redirect deposit creation dialog to the new checkout flow

Testing
- `npm test -- --run`
- `npm run lint` (fails: Unexpected any in GoogleCalendarButton.tsx)

------
https://chatgpt.com/codex/tasks/task_e_688f226e29f883238054b60a33ce24b5