### PR TITLE
Add user roles table and hook integration

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -42,7 +42,7 @@ app.get('/api/health', (_req, res) => {
 
 // Simple auth register
 app.post('/auth/register', async (req, res) => {
-  const { email, password, fullName } = req.body;
+  const { email, password, fullName, role = 'client' } = req.body;
   const { data, error } = await supabase.auth.admin.createUser({
     email,
     password,
@@ -52,7 +52,18 @@ app.post('/auth/register', async (req, res) => {
   if (error) {
     return res.status(400).json({ error: error.message });
   }
-  res.json({ user: data.user });
+
+  const user = data.user;
+  if (user) {
+    const { error: roleError } = await supabase
+      .from('user_roles')
+      .insert({ user_id: user.id, role });
+    if (roleError) {
+      return res.status(400).json({ error: roleError.message });
+    }
+  }
+
+  res.json({ user });
 });
 
 // login

--- a/src/hooks/useRole.tsx
+++ b/src/hooks/useRole.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react';
 import { useAuth } from '@/hooks/useAuth';
 import { supabase } from '@/integrations/supabase/client';
 
-type UserRole = 'admin' | 'lawyer' | 'client' | 'supplier' | 'customer';
+type UserRole = 'admin' | 'lawyer' | 'client' | 'supplier';
 
 interface UserRoleData {
   role: UserRole | null;
@@ -12,7 +12,6 @@ interface UserRoleData {
   isLawyer: boolean;
   isClient: boolean;
   isSupplier: boolean;
-  isCustomer: boolean;
 }
 
 export function useRole(): UserRoleData {
@@ -44,25 +43,24 @@ export function useRole(): UserRoleData {
     try {
       setLoading(true);
       
-      // יעיל יותר - רק בקשה אחת לprofiles
-      const { data: profile, error } = await supabase
-        .from('profiles')
+      const { data: roleRow, error } = await supabase
+        .from('user_roles')
         .select('role')
         .eq('user_id', user.id)
         .maybeSingle();
 
       if (error && error.code !== 'PGRST116') {
         console.error('Error fetching user role:', error);
-        setRole('customer');
+        setRole(null);
         return;
       }
 
-      const userRole = profile?.role as UserRole;
-      setRole(userRole || 'customer');
-      
+      const userRole = roleRow?.role as UserRole;
+      setRole(userRole || null);
+
     } catch (error) {
       console.error('Error fetching user role:', error);
-      setRole('customer'); // Default fallback
+      setRole(null);
     } finally {
       setLoading(false);
     }
@@ -86,7 +84,6 @@ export function useRole(): UserRoleData {
     isAdmin: role === 'admin',
     isLawyer: role === 'lawyer',
     isClient: role === 'client',
-    isSupplier: role === 'supplier',
-    isCustomer: role === 'customer'
+    isSupplier: role === 'supplier'
   };
 }

--- a/supabase/migrations/20250803120000_add_user_roles_table.sql
+++ b/supabase/migrations/20250803120000_add_user_roles_table.sql
@@ -1,0 +1,9 @@
+-- Create app_role enum and user_roles table
+CREATE TYPE IF NOT EXISTS public.app_role AS ENUM ('admin', 'lawyer', 'client', 'supplier');
+
+CREATE TABLE IF NOT EXISTS public.user_roles (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id uuid UNIQUE REFERENCES auth.users(id) ON DELETE CASCADE,
+    role public.app_role NOT NULL,
+    created_at timestamptz DEFAULT now()
+);


### PR DESCRIPTION
Creates migration defining app_role enum and user_roles table.
Updates registration endpoint to store role in user_roles.
Role hook now reads from user_roles and provides admin, lawyer, client and supplier flags.

------
https://chatgpt.com/codex/tasks/task_e_688f22b5d8548323ab7d1165ce4fd8d2