### PR TITLE
Use strict lead schema validation

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -27,7 +27,7 @@ const leadSchema = z
     source: z.string().optional(),
     estimated_budget: z.coerce.number().optional(),
   })
-  .passthrough();
+  .strict();
 
 app.use(express.json());
 app.use(
@@ -95,7 +95,7 @@ app.get('/api/leads', async (req, res) => {
 
 app.patch('/api/leads/:id', async (req, res) => {
   const { id } = req.params;
-  const result = leadSchema.partial().safeParse(req.body);
+  const result = leadSchema.partial().strict().safeParse(req.body);
   if (!result.success) {
     return res.status(400).json({ error: result.error.errors });
   }


### PR DESCRIPTION
Summary
- enforce strict validation on lead schema, rejecting unknown fields
- ensure patch route validates only defined properties

Testing
- npm test
- npm run lint (fails: Unexpected any in repository files)


------
https://chatgpt.com/codex/tasks/task_e_688f988b80c88323aed1472ee485d9b8