### PR TITLE
Use Vite env for Supabase client

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,9 +4,11 @@
 # ==================== LOCAL DEVELOPMENT ====================
 # For local development, create .env.local with these values
 
-# Supabase Configuration (automatically configured in client.ts)
-SUPABASE_URL="https://mlnwpocuvjnelttvscja.supabase.co"
-SUPABASE_ANON_KEY="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im1sbndwb2N1dmpuZWx0dHZzY2phIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTMzNzI0NDgsImV4cCI6MjA2ODk0ODQ0OH0.aDFfPvBZt58KFf9RjqYVpoLA2KwEbFjX2CPRfBhMWq0"
+# Supabase Configuration
+VITE_SUPABASE_URL=""
+VITE_SUPABASE_ANON_KEY=""
+SUPABASE_URL=""
+SUPABASE_ANON_KEY=""
 SUPABASE_SERVICE_ROLE_KEY="your-service-role-key"
 
 # Server Configuration (for backend Express server)

--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -2,8 +2,8 @@
 import { createClient } from '@supabase/supabase-js';
 import type { Database } from './types';
 
-const SUPABASE_URL = "https://mlnwpocuvjnelttvscja.supabase.co";
-const SUPABASE_PUBLISHABLE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im1sbndwb2N1dmpuZWx0dHZzY2phIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTMzNzI0NDgsImV4cCI6MjA2ODk0ODQ0OH0.aDFfPvBZt58KFf9RjqYVpoLA2KwEbFjX2CPRfBhMWq0";
+const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL || '';
+const SUPABASE_PUBLISHABLE_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY || '';
 
 // Import the supabase client like this:
 // import { supabase } from "@/integrations/supabase/client";


### PR DESCRIPTION
Summary
- Supabase client reads its URL and anon key from Vite env variables with empty string fallbacks.
- Example environment file provides placeholders for these entries.

Testing
- npm test
- npm run lint (failed with existing repository errors)
- npx eslint src/integrations/supabase/client.ts

------
https://chatgpt.com/codex/tasks/task_e_688f988a5e2c8323af54392896c70986