### PR TITLE
Use typed LeadDeposit objects in deposits hook

### DIFF
--- a/src/hooks/useDeposits.ts
+++ b/src/hooks/useDeposits.ts
@@ -6,9 +6,12 @@ export type LeadDeposit = {
   id: string;
   lead_id: string;
   lawyer_id: string;
+  quote_id?: string;
   amount: number;
+  deposit_type: string;
   status: string;
   payment_method: string;
+  transaction_id?: string;
   stripe_session_id?: string;
   paid_at?: string;
   created_at: string;
@@ -24,10 +27,11 @@ export const useLeadDeposits = () => {
     const { data, error } = await supabase
       .from('deposits')
       .select('*')
-      .order('created_at', { ascending: false });
-    
+      .order('created_at', { ascending: false })
+      .returns<LeadDeposit[]>();
+
     if (error) throw error;
-    return data as LeadDeposit[] || [];
+    return data ?? [];
   };
 
   const { data: deposits = [], isLoading, error } = useQuery({
@@ -39,10 +43,11 @@ export const useLeadDeposits = () => {
     mutationFn: async (newDeposit: NewLeadDeposit) => {
       const { data, error } = await supabase
         .from('deposits')
-        .insert(newDeposit as any)
+        .insert<NewLeadDeposit>(newDeposit)
         .select()
-        .single();
-      
+        .single()
+        .returns<LeadDeposit>();
+
       if (error) throw error;
       return data;
     },
@@ -63,11 +68,12 @@ export const useLeadDeposits = () => {
     mutationFn: async ({ id, values }: { id: string; values: Partial<LeadDeposit> }) => {
       const { data, error } = await supabase
         .from('deposits')
-        .update({ ...values, updated_at: new Date().toISOString() } as any)
+        .update<Partial<LeadDeposit>>({ ...values, updated_at: new Date().toISOString() })
         .eq('id', id)
         .select()
-        .single();
-      
+        .single()
+        .returns<LeadDeposit>();
+
       if (error) throw error;
       return data;
     },


### PR DESCRIPTION
## Summary
- replace unsafe casts with LeadDeposit types
- validate inserts and updates using Supabase generics

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688fa122368083238d0b5f73fd0bb565