### PR TITLE
enforce required env vars in server initialization

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -9,10 +9,10 @@ const paymentRoutes = require('./payments');
 const app = express();
 const port = process.env.PORT || 4000;
 
-const supabase = createClient(
-  process.env.SUPABASE_URL || '',
-  process.env.SUPABASE_SERVICE_ROLE || ''
-);
+const { SUPABASE_URL, SUPABASE_SERVICE_ROLE } = process.env;
+if (!SUPABASE_URL) throw new Error('Missing SUPABASE_URL environment variable');
+if (!SUPABASE_SERVICE_ROLE) throw new Error('Missing SUPABASE_SERVICE_ROLE environment variable');
+const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE);
 
 const leadSchema = z
   .object({

--- a/server/payments.js
+++ b/server/payments.js
@@ -4,14 +4,13 @@ const { createClient } = require('@supabase/supabase-js');
 
 const router = express.Router();
 
-const stripe = new Stripe(process.env.STRIPE_SECRET_KEY || '', {
-  apiVersion: '2022-11-15',
-});
-
-const supabase = createClient(
-  process.env.SUPABASE_URL || '',
-  process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_ROLE || ''
-);
+const { STRIPE_SECRET_KEY, SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, SUPABASE_SERVICE_ROLE } = process.env;
+if (!STRIPE_SECRET_KEY) throw new Error('Missing STRIPE_SECRET_KEY environment variable');
+const stripe = new Stripe(STRIPE_SECRET_KEY, { apiVersion: '2022-11-15' });
+if (!SUPABASE_URL) throw new Error('Missing SUPABASE_URL environment variable');
+const supabaseServiceRole = SUPABASE_SERVICE_ROLE_KEY || SUPABASE_SERVICE_ROLE;
+if (!supabaseServiceRole) throw new Error('Missing service role key environment variable');
+const supabase = createClient(SUPABASE_URL, supabaseServiceRole);
 
 router.post('/checkout', async (req, res) => {
   try {


### PR DESCRIPTION
## Summary
- validate Supabase and Stripe environment variables at startup

## Testing
- `npm run lint` (fails: Unexpected any. Specify a different type)
- `npx eslint server/app.js server/payments.js`
- `SUPABASE_URL=test SUPABASE_SERVICE_ROLE=role STRIPE_SECRET_KEY=key npm test`


------
https://chatgpt.com/codex/tasks/task_e_688fa12eb054832382539f2da9036fcc