### PR TITLE
Add court pages and routing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,6 +29,8 @@ import LeadsPortal from "./pages/LeadsPortal";
 import MeetingScheduler from "./pages/MeetingScheduler";
 import RoleDashboard from "./pages/RoleDashboard";
 import SupplierLeads from "./pages/SupplierLeads";
+import CourtDashboard from "./pages/court/CourtDashboard";
+import CourtSessionDetails from "./pages/court/CourtSessionDetails";
 import { RoleBasedRoute } from "./components/RoleBasedRoute";
 
 const App = () => (
@@ -121,16 +123,26 @@ const App = () => (
                               <Features />
                             </RoleBasedRoute>
                           } />
-                          <Route path="/matching" element={
-                            <RoleBasedRoute allowedRoles={['lawyer', 'admin']}>
-                              <Matching />
-                            </RoleBasedRoute>
-                          } />
-                          <Route path="/meeting-scheduler" element={<MeetingScheduler />} />
-                          <Route path="*" element={<NotFound />} />
-                        </Routes>
-                      </Layout>
-                    </ProtectedRoute>
+                            <Route path="/matching" element={
+                              <RoleBasedRoute allowedRoles={['lawyer', 'admin']}>
+                                <Matching />
+                              </RoleBasedRoute>
+                            } />
+                            <Route path="/court" element={
+                              <RoleBasedRoute allowedRoles={['lawyer', 'admin']}>
+                                <CourtDashboard />
+                              </RoleBasedRoute>
+                            } />
+                            <Route path="/court/session/:id" element={
+                              <RoleBasedRoute allowedRoles={['lawyer', 'admin']}>
+                                <CourtSessionDetails />
+                              </RoleBasedRoute>
+                            } />
+                            <Route path="/meeting-scheduler" element={<MeetingScheduler />} />
+                            <Route path="*" element={<NotFound />} />
+                          </Routes>
+                        </Layout>
+                      </ProtectedRoute>
                   }
                 />
               </Routes>

--- a/src/pages/court/CourtDashboard.tsx
+++ b/src/pages/court/CourtDashboard.tsx
@@ -1,0 +1,20 @@
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { Link } from "react-router-dom"
+
+const CourtDashboard = () => (
+  <div className="p-6 space-y-6">
+    <Card>
+      <CardHeader>
+        <CardTitle>Court Dashboard</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <Link to="/court/session/1">
+          <Button>View Session</Button>
+        </Link>
+      </CardContent>
+    </Card>
+  </div>
+)
+
+export default CourtDashboard;

--- a/src/pages/court/CourtSessionDetails.tsx
+++ b/src/pages/court/CourtSessionDetails.tsx
@@ -1,0 +1,23 @@
+import { useParams, Link } from "react-router-dom"
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+
+const CourtSessionDetails = () => {
+  const { id } = useParams()
+  return (
+    <div className="p-6 space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>Session {id}</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <Link to="/court">
+            <Button variant="outline">Back</Button>
+          </Link>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
+export default CourtSessionDetails;


### PR DESCRIPTION
## Summary
- add court dashboard and session details pages using shadcn components
- wire up /court and /court/session/:id routes in the main router

## Testing
- `npm test`
- `npx eslint src/App.tsx src/pages/court/CourtDashboard.tsx src/pages/court/CourtSessionDetails.tsx`
- `npm run lint` *(fails: Unexpected any in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_6899c885764c832392979aa63ea28e2d