### PR TITLE
Add court session and document tables with config update

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -7,6 +7,10 @@ schemas = ["public", "graphql_public"]
 extra_search_path = ["public", "extensions"]
 max_rows = 1000
 
+[db]
+port = 54322
+major_version = 15
+
 [auth]
 enabled = true
 port = 54324

--- a/supabase/migrations/20250811104256_create_court_tables.sql
+++ b/supabase/migrations/20250811104256_create_court_tables.sql
@@ -1,0 +1,25 @@
+CREATE TABLE public.court_sessions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  case_id UUID NOT NULL REFERENCES public.cases(id) ON DELETE CASCADE,
+  scheduled_at TIMESTAMPTZ NOT NULL,
+  location TEXT,
+  created_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE TABLE public.court_documents (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  case_id UUID NOT NULL REFERENCES public.cases(id) ON DELETE CASCADE,
+  session_id UUID REFERENCES public.court_sessions(id) ON DELETE CASCADE,
+  lawyer_id UUID REFERENCES public.lawyers(id) ON DELETE SET NULL,
+  payment_id UUID REFERENCES public.payments(id) ON DELETE SET NULL,
+  document_url TEXT NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE TABLE public.hearing_participants (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  session_id UUID NOT NULL REFERENCES public.court_sessions(id) ON DELETE CASCADE,
+  lawyer_id UUID REFERENCES public.lawyers(id) ON DELETE SET NULL,
+  role TEXT,
+  created_at TIMESTAMPTZ DEFAULT now()
+);


### PR DESCRIPTION
## Summary
- add court_sessions, court_documents, and hearing_participants tables with links to cases, lawyers, and payments
- configure database section in Supabase config

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any, missing dependencies)*
- `npx supabase db lint --workdir supabase` *(fails: connect ECONNREFUSED 127.0.0.1:54322)*

------
https://chatgpt.com/codex/tasks/task_e_6899c884b4148323905ee1bdcc79c3a1