### PR TITLE
Translate Hebrew text in SQL migrations to English

### DIFF
--- a/supabase/migrations/20250729125020-de91532b-6eed-4b36-84a2-c53f3f7a3765.sql
+++ b/supabase/migrations/20250729125020-de91532b-6eed-4b36-84a2-c53f3f7a3765.sql
@@ -47,16 +47,16 @@ CREATE TABLE IF NOT EXISTS public.lead_categories (
 
 -- Insert default legal categories
 INSERT INTO public.lead_categories (name, description) VALUES
-('אזרחי', 'תיקי משפט אזרחי'),
-('פלילי', 'תיקי משפט פלילי'),
-('משפחה', 'משפט משפחה וגירושין'),
-('עבודה', 'משפט עבודה'),
-('מקרקעין', 'משפט מקרקעין ונדלן'),
-('מסחרי', 'משפט מסחרי ועסקי'),
-('מינהלי', 'משפט מינהלי'),
-('ירושות', 'ירושות וצוואות'),
-('ביטוח', 'תביעות ביטוח'),
-('הוצאה לפועל', 'הוצאה לפועל וגבייה')
+('Civil', 'Civil legal cases'),
+('Criminal', 'Criminal legal cases'),
+('Family', 'Family law and divorce'),
+('Labor', 'Labor law'),
+('Real Estate', 'Real estate law'),
+('Commercial', 'Commercial and business law'),
+('Administrative', 'Administrative law'),
+('Inheritance', 'Inheritance and wills'),
+('Insurance', 'Insurance claims'),
+('Enforcement', 'Enforcement and collections')
 ON CONFLICT (name) DO NOTHING;
 
 -- Drop existing leads table if exists to recreate with new structure

--- a/supabase/migrations/20250729143643-a92ffed2-e8f4-4f75-87b6-9cfd5587f349.sql
+++ b/supabase/migrations/20250729143643-a92ffed2-e8f4-4f75-87b6-9cfd5587f349.sql
@@ -2,18 +2,18 @@
 
 -- Insert sample leads
 INSERT INTO public.leads (customer_name, customer_email, customer_phone, legal_category, case_description, status, urgency_level, estimated_budget) VALUES
-('דוד כהן', 'david@example.com', '050-1234567', 'דיני משפחה', 'גירושין וחלוקת רכוש', 'new', 'high', 15000),
-('שרה לוי', 'sarah@example.com', '052-9876543', 'דיני עבודה', 'פיטורים לא חוקיים', 'pending', 'medium', 8000),
-('יוסי אברהם', 'yossi@example.com', '054-5555555', 'דיני נזיקין', 'תאונת דרכים', 'contacted', 'high', 25000),
-('מירי דוד', 'miri@example.com', '053-1111111', 'דיני מקרקעין', 'רכישת דירה', 'new', 'low', 5000);
+('David Cohen', 'david@example.com', '050-1234567', 'Family Law', 'Divorce and division of property', 'new', 'high', 15000),
+('Sarah Levy', 'sarah@example.com', '052-9876543', 'Labor Law', 'Unlawful termination', 'pending', 'medium', 8000),
+('Yossi Avraham', 'yossi@example.com', '054-5555555', 'Tort Law', 'Car accident', 'contacted', 'high', 25000),
+('Miri David', 'miri@example.com', '053-1111111', 'Real Estate Law', 'Apartment purchase', 'new', 'low', 5000);
 
 -- Insert sample lawyers  
 INSERT INTO public.lawyers (profile_id, specializations, license_number, years_experience, hourly_rate, bio, location, law_firm) VALUES
-((SELECT id FROM profiles WHERE user_id = auth.uid() LIMIT 1), ARRAY['דיני משפחה', 'דיני עבודה'], '12345', 10, 800, 'עורך דין מנוסה בדיני משפחה ועבודה', 'תל אביב', 'משרד כהן ושות''');
+((SELECT id FROM profiles WHERE user_id = auth.uid() LIMIT 1), ARRAY['Family Law', 'Labor Law'], '12345', 10, 800, 'Experienced lawyer in family and labor law', 'Tel Aviv', 'Cohen & Partners Law Firm');
 
 -- Insert sample quotes
 INSERT INTO public.quotes (lead_id, lawyer_id, quote_amount, service_description, estimated_duration_days, status) VALUES
-((SELECT id FROM leads WHERE customer_name = 'דוד כהן' LIMIT 1), (SELECT id FROM lawyers LIMIT 1), 15000, 'ייצוג בהליכי גירושין', 90, 'pending');
+((SELECT id FROM leads WHERE customer_name = 'David Cohen' LIMIT 1), (SELECT id FROM lawyers LIMIT 1), 15000, 'Representation in divorce proceedings', 90, 'pending');
 
 -- Insert sample lawyer scores and tiers
 INSERT INTO public.lawyer_scores (lawyer_id, monthly_score, acceptance_rate, sla_hit_rate, nps_average, pro_bono_hours) VALUES

--- a/supabase/migrations/20250729143722-18192dde-795f-4390-babe-b8d13675f773.sql
+++ b/supabase/migrations/20250729143722-18192dde-795f-4390-babe-b8d13675f773.sql
@@ -2,7 +2,7 @@
 
 -- Insert sample leads with valid status values
 INSERT INTO public.leads (customer_name, customer_email, customer_phone, legal_category, case_description, status, urgency_level, estimated_budget) VALUES
-('דוד כהן', 'david@example.com', '050-1234567', 'דיני משפחה', 'גירושין וחלוקת רכוש', 'new', 'high', 15000),
-('שרה לוי', 'sarah@example.com', '052-9876543', 'דיני עבודה', 'פיטורים לא חוקיים', 'new', 'medium', 8000),
-('יוסי אברהם', 'yossi@example.com', '054-5555555', 'דיני נזיקין', 'תאונת דרכים', 'assigned', 'high', 25000),
-('מירי דוד', 'miri@example.com', '053-1111111', 'דיני מקרקעין', 'רכישת דירה', 'new', 'low', 5000);
+('David Cohen', 'david@example.com', '050-1234567', 'Family Law', 'Divorce and division of property', 'new', 'high', 15000),
+('Sarah Levy', 'sarah@example.com', '052-9876543', 'Labor Law', 'Unlawful termination', 'new', 'medium', 8000),
+('Yossi Avraham', 'yossi@example.com', '054-5555555', 'Tort Law', 'Car accident', 'assigned', 'high', 25000),
+('Miri David', 'miri@example.com', '053-1111111', 'Real Estate Law', 'Apartment purchase', 'new', 'low', 5000);

--- a/supabase/migrations/20250730082043-241b9e8e-303b-4611-8a1c-bf8bcd22d91e.sql
+++ b/supabase/migrations/20250730082043-241b9e8e-303b-4611-8a1c-bf8bcd22d91e.sql
@@ -1,27 +1,27 @@
--- הוספת נתונים לדוגמה למערכת
--- נוסיף נתונים לדוגמה כדי שהמשתמש יוכל לראות את המערכת עובדת
+-- Add sample data to the system
+-- Add sample data so the user can see the system working
 
--- נוסיף תפקיד למשתמש הנוכחי
+-- Add a role for the current user
 INSERT INTO public.user_roles (user_id, role) 
 VALUES ('d315c1e1-cf8b-44fc-8d8a-b13216d1c96d', 'admin')
 ON CONFLICT (user_id, role) DO NOTHING;
 
--- נוסיף לידים לדוגמה
+-- Add sample leads
 INSERT INTO public.leads (customer_name, customer_phone, customer_email, case_description, legal_category, urgency_level, status, estimated_budget) VALUES
-('יוסף כהן', '052-1234567', 'yosef@example.com', 'תאונת דרכים קשה, זקוק לייצוג משפטי', 'אזרחי', 'high', 'new', 50000),
-('שרה לוי', '053-9876543', 'sarah@example.com', 'בעיות עבודה - פיטורים לא חוקיים', 'עבודה', 'medium', 'new', 25000),
-('דוד אברהם', '054-5555555', 'david@example.com', 'גירושין וחלוקת רכוש', 'משפחה', 'low', 'converted', 15000),
-('מרים רוזן', '050-1111111', 'miriam@example.com', 'קניית דירה - בדיקת חוזה', 'נדלן', 'medium', 'new', 8000);
+('Yosef Cohen', '052-1234567', 'yosef@example.com', 'Serious car accident, needs legal representation', 'Civil', 'high', 'new', 50000),
+('Sarah Levy', '053-9876543', 'sarah@example.com', 'Work issues - unlawful termination', 'Labor', 'medium', 'new', 25000),
+('David Avraham', '054-5555555', 'david@example.com', 'Divorce and division of property', 'Family', 'low', 'converted', 15000),
+('Miriam Rosen', '050-1111111', 'miriam@example.com', 'Apartment purchase - contract review', 'Real Estate', 'medium', 'new', 8000);
 
--- נוסיף תיקים לדוגמה
+-- Add sample cases
 INSERT INTO public.cases (title, client_id, status, priority, legal_category, notes, estimated_budget, assigned_lawyer_id) VALUES
-('תביעת נזיקין - תאונת דרכים', (SELECT id FROM profiles WHERE user_id = 'd315c1e1-cf8b-44fc-8d8a-b13216d1c96d'), 'open', 'high', 'אזרחי', 'תיק דחוף - דיון בשבוע הבא', 50000, (SELECT id FROM profiles WHERE user_id = 'd315c1e1-cf8b-44fc-8d8a-b13216d1c96d')),
-('ייעוץ משפטי - הקמת חברה', (SELECT id FROM profiles WHERE user_id = 'd315c1e1-cf8b-44fc-8d8a-b13216d1c96d'), 'open', 'medium', 'מסחרי', 'הכנת מסמכי יסוד', 15000, (SELECT id FROM profiles WHERE user_id = 'd315c1e1-cf8b-44fc-8d8a-b13216d1c96d')),
-('גירושין - חלוקת רכוש', (SELECT id FROM profiles WHERE user_id = 'd315c1e1-cf8b-44fc-8d8a-b13216d1c96d'), 'closed', 'low', 'משפחה', 'תיק הסתיים בהסכמה', 25000, (SELECT id FROM profiles WHERE user_id = 'd315c1e1-cf8b-44fc-8d8a-b13216d1c96d'));
+('Tort claim - car accident', (SELECT id FROM profiles WHERE user_id = 'd315c1e1-cf8b-44fc-8d8a-b13216d1c96d'), 'open', 'high', 'Civil', 'Urgent case - hearing next week', 50000, (SELECT id FROM profiles WHERE user_id = 'd315c1e1-cf8b-44fc-8d8a-b13216d1c96d')),
+('Legal consultation - company formation', (SELECT id FROM profiles WHERE user_id = 'd315c1e1-cf8b-44fc-8d8a-b13216d1c96d'), 'open', 'medium', 'Commercial', 'Preparing foundational documents', 15000, (SELECT id FROM profiles WHERE user_id = 'd315c1e1-cf8b-44fc-8d8a-b13216d1c96d')),
+('Divorce - division of property', (SELECT id FROM profiles WHERE user_id = 'd315c1e1-cf8b-44fc-8d8a-b13216d1c96d'), 'closed', 'low', 'Family', 'Case ended with agreement', 25000, (SELECT id FROM profiles WHERE user_id = 'd315c1e1-cf8b-44fc-8d8a-b13216d1c96d'));
 
--- נוסיף אירועים לדוגמה (השבוע הקרוב)
+-- Add sample events (upcoming week)
 INSERT INTO public.events (title, start_time, end_time, description, lawyer_id) VALUES
-('פגישה עם יוסף כהן', NOW() + INTERVAL '1 day' + INTERVAL '10 hours', NOW() + INTERVAL '1 day' + INTERVAL '11 hours', 'פגישת ייעוץ ראשונית', (SELECT id FROM profiles WHERE user_id = 'd315c1e1-cf8b-44fc-8d8a-b13216d1c96d')),
-('דיון בבית משפט', NOW() + INTERVAL '2 days' + INTERVAL '14 hours', NOW() + INTERVAL '2 days' + INTERVAL '16 hours', 'בית משפט שלום תל אביב', (SELECT id FROM profiles WHERE user_id = 'd315c1e1-cf8b-44fc-8d8a-b13216d1c96d')),
-('הכנת מסמכים', NOW() + INTERVAL '3 days' + INTERVAL '9 hours', NOW() + INTERVAL '3 days' + INTERVAL '12 hours', 'עבודה פנימית על תיק אברהם', (SELECT id FROM profiles WHERE user_id = 'd315c1e1-cf8b-44fc-8d8a-b13216d1c96d')),
-('פגישת זום עם שרה לוי', NOW() + INTERVAL '4 days' + INTERVAL '16 hours', NOW() + INTERVAL '4 days' + INTERVAL '17 hours', 'פגישה וירטואלית', (SELECT id FROM profiles WHERE user_id = 'd315c1e1-cf8b-44fc-8d8a-b13216d1c96d'));
+('Meeting with Yosef Cohen', NOW() + INTERVAL '1 day' + INTERVAL '10 hours', NOW() + INTERVAL '1 day' + INTERVAL '11 hours', 'Initial consultation meeting', (SELECT id FROM profiles WHERE user_id = 'd315c1e1-cf8b-44fc-8d8a-b13216d1c96d')),
+('Court hearing', NOW() + INTERVAL '2 days' + INTERVAL '14 hours', NOW() + INTERVAL '2 days' + INTERVAL '16 hours', 'Tel Aviv Magistrate Court', (SELECT id FROM profiles WHERE user_id = 'd315c1e1-cf8b-44fc-8d8a-b13216d1c96d')),
+('Document preparation', NOW() + INTERVAL '3 days' + INTERVAL '9 hours', NOW() + INTERVAL '3 days' + INTERVAL '12 hours', 'Internal work on Avraham case', (SELECT id FROM profiles WHERE user_id = 'd315c1e1-cf8b-44fc-8d8a-b13216d1c96d')),
+('Zoom meeting with Sarah Levy', NOW() + INTERVAL '4 days' + INTERVAL '16 hours', NOW() + INTERVAL '4 days' + INTERVAL '17 hours', 'Virtual meeting', (SELECT id FROM profiles WHERE user_id = 'd315c1e1-cf8b-44fc-8d8a-b13216d1c96d'));

--- a/supabase/migrations/20250730082422-ff500056-b908-46a9-8c1f-a002952173c1.sql
+++ b/supabase/migrations/20250730082422-ff500056-b908-46a9-8c1f-a002952173c1.sql
@@ -1,7 +1,7 @@
--- תיקון מדיניות RLS כדי שהמשתמש יוכל לראות נתונים
--- נעדכן את המדיניות להיות יותר פתוחה למשתמשים מאומתים
+-- Fix RLS policies so the user can view data
+-- Update policies to be more open to authenticated users
 
--- תיקון מדיניות לידים - תאפשר למשתמשים מאומתים לראות לידים
+-- Fix leads policy - allow authenticated users to view leads
 DROP POLICY IF EXISTS "Lawyers can view assigned leads" ON public.leads;
 DROP POLICY IF EXISTS "Admins can manage all leads" ON public.leads;
 
@@ -14,7 +14,7 @@ CREATE POLICY "Authenticated users can manage leads" ON public.leads
   USING (true)
   WITH CHECK (true);
 
--- תיקון מדיניות תיקים - תאפשר למשתמשים מאומתים לראות תיקים
+-- Fix cases policy - allow authenticated users to view cases
 DROP POLICY IF EXISTS "Lawyers can view assigned cases" ON public.cases;
 DROP POLICY IF EXISTS "Lawyers can create cases" ON public.cases;
 DROP POLICY IF EXISTS "Lawyers can update assigned cases" ON public.cases;
@@ -28,7 +28,7 @@ CREATE POLICY "Authenticated users can manage cases" ON public.cases
   USING (true)
   WITH CHECK (true);
 
--- תיקון מדיניות אירועים - תאפשר למשתמשים מאומתים לראות אירועים
+-- Fix events policy - allow authenticated users to view events
 DROP POLICY IF EXISTS "Users can view their events" ON public.events;
 DROP POLICY IF EXISTS "Lawyers can manage events" ON public.events;
 

--- a/supabase/migrations/20250730083328-df3f213e-35c3-461c-a825-abf5868720a3.sql
+++ b/supabase/migrations/20250730083328-df3f213e-35c3-461c-a825-abf5868720a3.sql
@@ -14,7 +14,7 @@
 INSERT INTO profiles (user_id, full_name, role) 
 SELECT 
   '00000000-0000-0000-0000-000000000000'::uuid as user_id,
-  'מערכת מוכנה לרישום' as full_name,
+  'System ready for registration' as full_name,
   'admin' as role
 WHERE NOT EXISTS (
   SELECT 1 FROM profiles 

--- a/supabase/migrations/20250730145228-d0005b57-81a4-4c83-8d3f-e4a89e8bab29.sql
+++ b/supabase/migrations/20250730145228-d0005b57-81a4-4c83-8d3f-e4a89e8bab29.sql
@@ -1,39 +1,39 @@
 -- Insert sample profiles
 INSERT INTO public.profiles (id, user_id, full_name, phone, company_name, role, whatsapp_number) VALUES
-  ('11111111-1111-1111-1111-111111111111', '11111111-1111-1111-1111-111111111111', 'עו"ד דן כהן', '0501234567', 'משרד עורכי דין כהן ושות', 'lawyer', '972501234567'),
-  ('22222222-2222-2222-2222-222222222222', '22222222-2222-2222-2222-222222222222', 'עו"ד שרה לוי', '0509876543', 'משרד לוי ושות', 'lawyer', '972509876543'),
-  ('33333333-3333-3333-3333-333333333333', '33333333-3333-3333-3333-333333333333', 'יוסי ישראלי', '0507654321', 'חברת ישראלי בע"מ', 'customer', '972507654321'),
-  ('44444444-4444-4444-4444-444444444444', '44444444-4444-4444-4444-444444444444', 'מיכל אברהם', '0503456789', 'אברהם ושות', 'customer', '972503456789'),
-  ('55555555-5555-5555-5555-555555555555', '55555555-5555-5555-5555-555555555555', 'עו"ד רון מזרחי', '0502345678', 'משרד מזרחי', 'lawyer', '972502345678')
+  ('11111111-1111-1111-1111-111111111111', '11111111-1111-1111-1111-111111111111', 'Attorney Dan Cohen', '0501234567', 'Cohen & Partners Law Firm', 'lawyer', '972501234567'),
+  ('22222222-2222-2222-2222-222222222222', '22222222-2222-2222-2222-222222222222', 'Attorney Sarah Levy', '0509876543', 'Levy & Partners', 'lawyer', '972509876543'),
+  ('33333333-3333-3333-3333-333333333333', '33333333-3333-3333-3333-333333333333', 'Yossi Israeli', '0507654321', 'Israeli Ltd.', 'customer', '972507654321'),
+  ('44444444-4444-4444-4444-444444444444', '44444444-4444-4444-4444-444444444444', 'Michal Avraham', '0503456789', 'Avraham & Partners', 'customer', '972503456789'),
+  ('55555555-5555-5555-5555-555555555555', '55555555-5555-5555-5555-555555555555', 'Attorney Ron Mizrahi', '0502345678', 'Mizrahi Firm', 'lawyer', '972502345678')
 ON CONFLICT (id) DO NOTHING;
 
 -- Insert sample lawyers
 INSERT INTO public.lawyers (id, profile_id, specializations, years_experience, hourly_rate, rating, bio, law_firm, location, license_number, verification_status, is_active, availability_status, total_cases) VALUES
-  ('aaaa1111-1111-1111-1111-111111111111', '11111111-1111-1111-1111-111111111111', ARRAY['דיני משפחה', 'דיני עבודה'], 15, 500, 4.8, 'עורך דין מנוסה המתמחה בדיני משפחה ועבודה', 'משרד עורכי דין כהן ושות', 'תל אביב', '12345', 'verified', true, 'available', 45),
-  ('bbbb2222-2222-2222-2222-222222222222', '22222222-2222-2222-2222-222222222222', ARRAY['דיני חוזים', 'דיני נזקין'], 12, 450, 4.6, 'מומחית בדיני חוזים ונזקין', 'משרד לוי ושות', 'חיפה', '67890', 'verified', true, 'available', 38),
-  ('cccc3333-3333-3333-3333-333333333333', '55555555-5555-5555-5555-555555555555', ARRAY['דיני חברות', 'דיני מקרקעין'], 8, 400, 4.4, 'עורך דין צעיר ומבטיח', 'משרד מזרחי', 'ירושלים', '54321', 'verified', true, 'available', 22)
+  ('aaaa1111-1111-1111-1111-111111111111', '11111111-1111-1111-1111-111111111111', ARRAY['Family Law', 'Labor Law'], 15, 500, 4.8, 'Experienced lawyer specializing in family and labor law', 'Cohen & Partners Law Firm', 'Tel Aviv', '12345', 'verified', true, 'available', 45),
+  ('bbbb2222-2222-2222-2222-222222222222', '22222222-2222-2222-2222-222222222222', ARRAY['Contract Law', 'Tort Law'], 12, 450, 4.6, 'Expert in contract and tort law', 'Levy & Partners', 'Haifa', '67890', 'verified', true, 'available', 38),
+  ('cccc3333-3333-3333-3333-333333333333', '55555555-5555-5555-5555-555555555555', ARRAY['Corporate Law', 'Real Estate Law'], 8, 400, 4.4, 'Promising young lawyer', 'Mizrahi Firm', 'Jerusalem', '54321', 'verified', true, 'available', 22)
 ON CONFLICT (id) DO NOTHING;
 
 -- Insert sample leads
 INSERT INTO public.leads (id, customer_name, customer_phone, customer_email, legal_category, case_description, urgency_level, estimated_budget, preferred_location, source, status, assigned_lawyer_id) VALUES
-  ('lead1111-1111-1111-1111-111111111111', 'אמיר כהן', '0501111111', 'amir@example.com', 'דיני משפחה', 'תיק גירושין מורכב עם ילדים קטינים', 'high', 15000, 'תל אביב', 'website', 'assigned', 'aaaa1111-1111-1111-1111-111111111111'),
-  ('lead2222-2222-2222-2222-222222222222', 'רחל דוד', '0502222222', 'rachel@example.com', 'דיני עבודה', 'פיטורים לא חוקיים מהעבודה', 'medium', 8000, 'חיפה', 'referral', 'new', NULL),
-  ('lead3333-3333-3333-3333-333333333333', 'משה לוי', '0503333333', 'moshe@example.com', 'דיני נזקין', 'תאונת דרכים עם נזקים כבדים', 'high', 25000, 'תל אביב', 'google', 'converted', 'bbbb2222-2222-2222-2222-222222222222'),
-  ('lead4444-4444-4444-4444-444444444444', 'נועה רוזן', '0504444444', 'noa@example.com', 'דיני חוזים', 'הפרת חוזה עסקי', 'low', 5000, 'ירושלים', 'website', 'new', NULL)
+  ('lead1111-1111-1111-1111-111111111111', 'Amir Cohen', '0501111111', 'amir@example.com', 'Family Law', 'Complex divorce case with minor children', 'high', 15000, 'Tel Aviv', 'website', 'assigned', 'aaaa1111-1111-1111-1111-111111111111'),
+  ('lead2222-2222-2222-2222-222222222222', 'Rachel David', '0502222222', 'rachel@example.com', 'Labor Law', 'Unlawful termination from work', 'medium', 8000, 'Haifa', 'referral', 'new', NULL),
+  ('lead3333-3333-3333-3333-333333333333', 'Moshe Levy', '0503333333', 'moshe@example.com', 'Tort Law', 'Car accident with heavy damages', 'high', 25000, 'Tel Aviv', 'google', 'converted', 'bbbb2222-2222-2222-2222-222222222222'),
+  ('lead4444-4444-4444-4444-444444444444', 'Noa Rosen', '0504444444', 'noa@example.com', 'Contract Law', 'Business contract breach', 'low', 5000, 'Jerusalem', 'website', 'new', NULL)
 ON CONFLICT (id) DO NOTHING;
 
 -- Insert sample cases
 INSERT INTO public.cases (id, title, client_id, legal_category, status, priority, estimated_budget, assigned_lawyer_id, notes, opened_at) VALUES
-  ('case1111-1111-1111-1111-111111111111', 'תיק גירושין - אמיר כהן', '33333333-3333-3333-3333-333333333333', 'דיני משפחה', 'open', 'high', 15000, 'aaaa1111-1111-1111-1111-111111111111', 'תיק מורכב עם ילדים', '2024-01-15 10:00:00+00'),
-  ('case2222-2222-2222-2222-222222222222', 'תאונת דרכים - משה לוי', '44444444-4444-4444-4444-444444444444', 'דיני נזקין', 'open', 'high', 25000, 'bbbb2222-2222-2222-2222-222222222222', 'נזקים כבדים ונכות', '2024-01-20 14:30:00+00'),
-  ('case3333-3333-3333-3333-333333333333', 'הפרת חוזה - חברת ABC', '33333333-3333-3333-3333-333333333333', 'דיני חוזים', 'closed', 'medium', 12000, 'cccc3333-3333-3333-3333-333333333333', 'הושג פשר', '2023-12-01 09:00:00+00')
+  ('case1111-1111-1111-1111-111111111111', 'Divorce Case - Amir Cohen', '33333333-3333-3333-3333-333333333333', 'Family Law', 'open', 'high', 15000, 'aaaa1111-1111-1111-1111-111111111111', 'Complex case with children', '2024-01-15 10:00:00+00'),
+  ('case2222-2222-2222-2222-222222222222', 'Car Accident - Moshe Levy', '44444444-4444-4444-4444-444444444444', 'Tort Law', 'open', 'high', 25000, 'bbbb2222-2222-2222-2222-222222222222', 'Severe damages and disability', '2024-01-20 14:30:00+00'),
+  ('case3333-3333-3333-3333-333333333333', 'Contract Breach - ABC Company', '33333333-3333-3333-3333-333333333333', 'Contract Law', 'closed', 'medium', 12000, 'cccc3333-3333-3333-3333-333333333333', 'Settlement reached', '2023-12-01 09:00:00+00')
 ON CONFLICT (id) DO NOTHING;
 
 -- Insert sample events
 INSERT INTO public.events (id, title, start_time, end_time, client_id, case_id, lawyer_id, description) VALUES
-  ('event111-1111-1111-1111-111111111111', 'פגישה עם לקוח - אמיר כהן', '2024-02-01 10:00:00+00', '2024-02-01 11:30:00+00', '33333333-3333-3333-3333-333333333333', 'case1111-1111-1111-1111-111111111111', 'aaaa1111-1111-1111-1111-111111111111', 'פגישת התייעצות ראשונה'),
-  ('event222-2222-2222-2222-222222222222', 'דיון בבית משפט', '2024-02-05 09:00:00+00', '2024-02-05 12:00:00+00', '44444444-4444-4444-4444-444444444444', 'case2222-2222-2222-2222-222222222222', 'bbbb2222-2222-2222-2222-222222222222', 'דיון בתביעת נזקין'),
-  ('event333-3333-3333-3333-333333333333', 'פגישת צוות', '2024-02-03 16:00:00+00', '2024-02-03 17:00:00+00', NULL, NULL, 'aaaa1111-1111-1111-1111-111111111111', 'סקירת תיקים שוטפים')
+  ('event111-1111-1111-1111-111111111111', 'Meeting with Client - Amir Cohen', '2024-02-01 10:00:00+00', '2024-02-01 11:30:00+00', '33333333-3333-3333-3333-333333333333', 'case1111-1111-1111-1111-111111111111', 'aaaa1111-1111-1111-1111-111111111111', 'Initial consultation meeting'),
+  ('event222-2222-2222-2222-222222222222', 'Court hearing', '2024-02-05 09:00:00+00', '2024-02-05 12:00:00+00', '44444444-4444-4444-4444-444444444444', 'case2222-2222-2222-2222-222222222222', 'bbbb2222-2222-2222-2222-222222222222', 'Tort lawsuit hearing'),
+  ('event333-3333-3333-3333-333333333333', 'Team meeting', '2024-02-03 16:00:00+00', '2024-02-03 17:00:00+00', NULL, NULL, 'aaaa1111-1111-1111-1111-111111111111', 'Review of ongoing cases')
 ON CONFLICT (id) DO NOTHING;
 
 -- Insert sample lawyer scores
@@ -52,8 +52,8 @@ ON CONFLICT (id) DO NOTHING;
 
 -- Insert sample quotes
 INSERT INTO public.quotes (id, lead_id, lawyer_id, quote_amount, service_description, payment_terms, estimated_duration_days, status, valid_until) VALUES
-  ('quote111-1111-1111-1111-111111111111', 'lead1111-1111-1111-1111-111111111111', 'aaaa1111-1111-1111-1111-111111111111', 15000, 'טיפול מלא בתיק גירושין כולל ייצוג בבית המשפט', '50% מקדמה, יתרה בתשלומים', 90, 'accepted', '2024-02-15 23:59:59+00'),
-  ('quote222-2222-2222-2222-222222222222', 'lead3333-3333-3333-3333-333333333333', 'bbbb2222-2222-2222-2222-222222222222', 25000, 'ייצוג בתביעת נזקין מתאונת דרכים', 'תשלום בהצלחה - 25%', 120, 'accepted', '2024-02-20 23:59:59+00')
+  ('quote111-1111-1111-1111-111111111111', 'lead1111-1111-1111-1111-111111111111', 'aaaa1111-1111-1111-1111-111111111111', 15000, 'Full handling of divorce case including court representation', '50% deposit, remainder in installments', 90, 'accepted', '2024-02-15 23:59:59+00'),
+  ('quote222-2222-2222-2222-222222222222', 'lead3333-3333-3333-3333-333333333333', 'bbbb2222-2222-2222-2222-222222222222', 25000, 'Representation in tort claim from car accident', 'Payment upon success - 25%', 120, 'accepted', '2024-02-20 23:59:59+00')
 ON CONFLICT (id) DO NOTHING;
 
 -- Insert sample deposits

--- a/supabase/migrations/20250730170818-4ead8ab0-d694-4b39-89f7-1dc0fb59b0d4.sql
+++ b/supabase/migrations/20250730170818-4ead8ab0-d694-4b39-89f7-1dc0fb59b0d4.sql
@@ -1,40 +1,40 @@
 -- Insert sample profiles with correct roles
 INSERT INTO public.profiles (id, user_id, full_name, phone, company_name, role, whatsapp_number) VALUES
-  ('11111111-1111-1111-1111-111111111111', '11111111-1111-1111-1111-111111111111', 'עו"ד דן כהן', '0501234567', 'משרד עורכי דין כהן ושות', 'supplier', '972501234567'),
-  ('22222222-2222-2222-2222-222222222222', '22222222-2222-2222-2222-222222222222', 'עו"ד שרה לוי', '0509876543', 'משרד לוי ושות', 'supplier', '972509876543'),
-  ('33333333-3333-3333-3333-333333333333', '33333333-3333-3333-3333-333333333333', 'יוסי ישראלי', '0507654321', 'חברת ישראלי בע"מ', 'customer', '972507654321'),
-  ('44444444-4444-4444-4444-444444444444', '44444444-4444-4444-4444-444444444444', 'מיכל אברהם', '0503456789', 'אברהם ושות', 'customer', '972503456789'),
-  ('55555555-5555-5555-5555-555555555555', '55555555-5555-5555-5555-555555555555', 'עו"ד רון מזרחי', '0502345678', 'משרד מזרחי', 'supplier', '972502345678'),
-  ('66666666-6666-6666-6666-666666666666', '66666666-6666-6666-6666-666666666666', 'מנהל מערכת', '0501111222', 'חברת המערכת', 'admin', '972501111222')
+  ('11111111-1111-1111-1111-111111111111', '11111111-1111-1111-1111-111111111111', 'Attorney Dan Cohen', '0501234567', 'Cohen & Partners Law Firm', 'supplier', '972501234567'),
+  ('22222222-2222-2222-2222-222222222222', '22222222-2222-2222-2222-222222222222', 'Attorney Sarah Levy', '0509876543', 'Levy & Partners', 'supplier', '972509876543'),
+  ('33333333-3333-3333-3333-333333333333', '33333333-3333-3333-3333-333333333333', 'Yossi Israeli', '0507654321', 'Israeli Ltd.', 'customer', '972507654321'),
+  ('44444444-4444-4444-4444-444444444444', '44444444-4444-4444-4444-444444444444', 'Michal Avraham', '0503456789', 'Avraham & Partners', 'customer', '972503456789'),
+  ('55555555-5555-5555-5555-555555555555', '55555555-5555-5555-5555-555555555555', 'Attorney Ron Mizrahi', '0502345678', 'Mizrahi Firm', 'supplier', '972502345678'),
+  ('66666666-6666-6666-6666-666666666666', '66666666-6666-6666-6666-666666666666', 'System Administrator', '0501111222', 'System Company', 'admin', '972501111222')
 ON CONFLICT (id) DO NOTHING;
 
 -- Insert sample lawyers (suppliers in this context)
 INSERT INTO public.lawyers (id, profile_id, specializations, years_experience, hourly_rate, rating, bio, law_firm, location, license_number, verification_status, is_active, availability_status, total_cases) VALUES
-  ('aaaa1111-1111-1111-1111-111111111111', '11111111-1111-1111-1111-111111111111', ARRAY['דיני משפחה', 'דיני עבודה'], 15, 500, 4.8, 'עורך דין מנוסה המתמחה בדיני משפחה ועבודה', 'משרד עורכי דין כהן ושות', 'תל אביב', '12345', 'verified', true, 'available', 45),
-  ('bbbb2222-2222-2222-2222-222222222222', '22222222-2222-2222-2222-222222222222', ARRAY['דיני חוזים', 'דיני נזקין'], 12, 450, 4.6, 'מומחית בדיני חוזים ונזקין', 'משרד לוי ושות', 'חיפה', '67890', 'verified', true, 'available', 38),
-  ('cccc3333-3333-3333-3333-333333333333', '55555555-5555-5555-5555-555555555555', ARRAY['דיני חברות', 'דיני מקרקעין'], 8, 400, 4.4, 'עורך דין צעיר ומבטיח', 'משרד מזרחי', 'ירושלים', '54321', 'verified', true, 'available', 22)
+  ('aaaa1111-1111-1111-1111-111111111111', '11111111-1111-1111-1111-111111111111', ARRAY['Family Law', 'Labor Law'], 15, 500, 4.8, 'Experienced lawyer specializing in family and labor law', 'Cohen & Partners Law Firm', 'Tel Aviv', '12345', 'verified', true, 'available', 45),
+  ('bbbb2222-2222-2222-2222-222222222222', '22222222-2222-2222-2222-222222222222', ARRAY['Contract Law', 'Tort Law'], 12, 450, 4.6, 'Expert in contract and tort law', 'Levy & Partners', 'Haifa', '67890', 'verified', true, 'available', 38),
+  ('cccc3333-3333-3333-3333-333333333333', '55555555-5555-5555-5555-555555555555', ARRAY['Corporate Law', 'Real Estate Law'], 8, 400, 4.4, 'Promising young lawyer', 'Mizrahi Firm', 'Jerusalem', '54321', 'verified', true, 'available', 22)
 ON CONFLICT (id) DO NOTHING;
 
 -- Insert sample leads
 INSERT INTO public.leads (id, customer_name, customer_phone, customer_email, legal_category, case_description, urgency_level, estimated_budget, preferred_location, source, status, assigned_lawyer_id) VALUES
-  ('lead1111-1111-1111-1111-111111111111', 'אמיר כהן', '0501111111', 'amir@example.com', 'דיני משפחה', 'תיק גירושין מורכב עם ילדים קטינים', 'high', 15000, 'תל אביב', 'website', 'assigned', 'aaaa1111-1111-1111-1111-111111111111'),
-  ('lead2222-2222-2222-2222-222222222222', 'רחל דוד', '0502222222', 'rachel@example.com', 'דיני עבודה', 'פיטורים לא חוקיים מהעבודה', 'medium', 8000, 'חיפה', 'referral', 'new', NULL),
-  ('lead3333-3333-3333-3333-333333333333', 'משה לוי', '0503333333', 'moshe@example.com', 'דיני נזקין', 'תאונת דרכים עם נזקים כבדים', 'high', 25000, 'תל אביב', 'google', 'converted', 'bbbb2222-2222-2222-2222-222222222222'),
-  ('lead4444-4444-4444-4444-444444444444', 'נועה רוזן', '0504444444', 'noa@example.com', 'דיני חוזים', 'הפרת חוזה עסקי', 'low', 5000, 'ירושלים', 'website', 'new', NULL)
+  ('lead1111-1111-1111-1111-111111111111', 'Amir Cohen', '0501111111', 'amir@example.com', 'Family Law', 'Complex divorce case with minor children', 'high', 15000, 'Tel Aviv', 'website', 'assigned', 'aaaa1111-1111-1111-1111-111111111111'),
+  ('lead2222-2222-2222-2222-222222222222', 'Rachel David', '0502222222', 'rachel@example.com', 'Labor Law', 'Unlawful termination from work', 'medium', 8000, 'Haifa', 'referral', 'new', NULL),
+  ('lead3333-3333-3333-3333-333333333333', 'Moshe Levy', '0503333333', 'moshe@example.com', 'Tort Law', 'Car accident with heavy damages', 'high', 25000, 'Tel Aviv', 'google', 'converted', 'bbbb2222-2222-2222-2222-222222222222'),
+  ('lead4444-4444-4444-4444-444444444444', 'Noa Rosen', '0504444444', 'noa@example.com', 'Contract Law', 'Business contract breach', 'low', 5000, 'Jerusalem', 'website', 'new', NULL)
 ON CONFLICT (id) DO NOTHING;
 
 -- Insert sample cases
 INSERT INTO public.cases (id, title, client_id, legal_category, status, priority, estimated_budget, assigned_lawyer_id, notes, opened_at) VALUES
-  ('case1111-1111-1111-1111-111111111111', 'תיק גירושין - אמיר כהן', '33333333-3333-3333-3333-333333333333', 'דיני משפחה', 'open', 'high', 15000, 'aaaa1111-1111-1111-1111-111111111111', 'תיק מורכב עם ילדים', '2024-01-15 10:00:00+00'),
-  ('case2222-2222-2222-2222-222222222222', 'תאונת דרכים - משה לוי', '44444444-4444-4444-4444-444444444444', 'דיני נזקין', 'open', 'high', 25000, 'bbbb2222-2222-2222-2222-222222222222', 'נזקים כבדים ונכות', '2024-01-20 14:30:00+00'),
-  ('case3333-3333-3333-3333-333333333333', 'הפרת חוזה - חברת ABC', '33333333-3333-3333-3333-333333333333', 'דיני חוזים', 'closed', 'medium', 12000, 'cccc3333-3333-3333-3333-333333333333', 'הושג פשר', '2023-12-01 09:00:00+00')
+  ('case1111-1111-1111-1111-111111111111', 'Divorce Case - Amir Cohen', '33333333-3333-3333-3333-333333333333', 'Family Law', 'open', 'high', 15000, 'aaaa1111-1111-1111-1111-111111111111', 'Complex case with children', '2024-01-15 10:00:00+00'),
+  ('case2222-2222-2222-2222-222222222222', 'Car Accident - Moshe Levy', '44444444-4444-4444-4444-444444444444', 'Tort Law', 'open', 'high', 25000, 'bbbb2222-2222-2222-2222-222222222222', 'Severe damages and disability', '2024-01-20 14:30:00+00'),
+  ('case3333-3333-3333-3333-333333333333', 'Contract Breach - ABC Company', '33333333-3333-3333-3333-333333333333', 'Contract Law', 'closed', 'medium', 12000, 'cccc3333-3333-3333-3333-333333333333', 'Settlement reached', '2023-12-01 09:00:00+00')
 ON CONFLICT (id) DO NOTHING;
 
 -- Insert sample events
 INSERT INTO public.events (id, title, start_time, end_time, client_id, case_id, lawyer_id, description) VALUES
-  ('event111-1111-1111-1111-111111111111', 'פגישה עם לקוח - אמיר כהן', '2024-02-01 10:00:00+00', '2024-02-01 11:30:00+00', '33333333-3333-3333-3333-333333333333', 'case1111-1111-1111-1111-111111111111', 'aaaa1111-1111-1111-1111-111111111111', 'פגישת התייעצות ראשונה'),
-  ('event222-2222-2222-2222-222222222222', 'דיון בבית משפט', '2024-02-05 09:00:00+00', '2024-02-05 12:00:00+00', '44444444-4444-4444-4444-444444444444', 'case2222-2222-2222-2222-222222222222', 'bbbb2222-2222-2222-2222-222222222222', 'דיון בתביעת נזקין'),
-  ('event333-3333-3333-3333-333333333333', 'פגישת צוות', '2024-02-03 16:00:00+00', '2024-02-03 17:00:00+00', NULL, NULL, 'aaaa1111-1111-1111-1111-111111111111', 'סקירת תיקים שוטפים')
+  ('event111-1111-1111-1111-111111111111', 'Meeting with Client - Amir Cohen', '2024-02-01 10:00:00+00', '2024-02-01 11:30:00+00', '33333333-3333-3333-3333-333333333333', 'case1111-1111-1111-1111-111111111111', 'aaaa1111-1111-1111-1111-111111111111', 'Initial consultation meeting'),
+  ('event222-2222-2222-2222-222222222222', 'Court hearing', '2024-02-05 09:00:00+00', '2024-02-05 12:00:00+00', '44444444-4444-4444-4444-444444444444', 'case2222-2222-2222-2222-222222222222', 'bbbb2222-2222-2222-2222-222222222222', 'Tort lawsuit hearing'),
+  ('event333-3333-3333-3333-333333333333', 'Team meeting', '2024-02-03 16:00:00+00', '2024-02-03 17:00:00+00', NULL, NULL, 'aaaa1111-1111-1111-1111-111111111111', 'Review of ongoing cases')
 ON CONFLICT (id) DO NOTHING;
 
 -- Insert sample lawyer scores

--- a/supabase/migrations/20250730170944-6c9c34d2-103b-40ad-b010-5422109eaa94.sql
+++ b/supabase/migrations/20250730170944-6c9c34d2-103b-40ad-b010-5422109eaa94.sql
@@ -1,40 +1,40 @@
 -- Insert sample profiles with correct roles and valid UUIDs
 INSERT INTO public.profiles (id, user_id, full_name, phone, company_name, role, whatsapp_number) VALUES
-  ('11111111-1111-1111-1111-111111111111', '11111111-1111-1111-1111-111111111111', 'עו"ד דן כהן', '0501234567', 'משרד עורכי דין כהן ושות', 'supplier', '972501234567'),
-  ('22222222-2222-2222-2222-222222222222', '22222222-2222-2222-2222-222222222222', 'עו"ד שרה לוי', '0509876543', 'משרד לוי ושות', 'supplier', '972509876543'),
-  ('33333333-3333-3333-3333-333333333333', '33333333-3333-3333-3333-333333333333', 'יוסי ישראלי', '0507654321', 'חברת ישראלי בע"מ', 'customer', '972507654321'),
-  ('44444444-4444-4444-4444-444444444444', '44444444-4444-4444-4444-444444444444', 'מיכל אברהם', '0503456789', 'אברהם ושות', 'customer', '972503456789'),
-  ('55555555-5555-5555-5555-555555555555', '55555555-5555-5555-5555-555555555555', 'עו"ד רון מזרחי', '0502345678', 'משרד מזרחי', 'supplier', '972502345678'),
-  ('66666666-6666-6666-6666-666666666666', '66666666-6666-6666-6666-666666666666', 'מנהל מערכת', '0501111222', 'חברת המערכת', 'admin', '972501111222')
+  ('11111111-1111-1111-1111-111111111111', '11111111-1111-1111-1111-111111111111', 'Attorney Dan Cohen', '0501234567', 'Cohen & Partners Law Firm', 'supplier', '972501234567'),
+  ('22222222-2222-2222-2222-222222222222', '22222222-2222-2222-2222-222222222222', 'Attorney Sarah Levy', '0509876543', 'Levy & Partners', 'supplier', '972509876543'),
+  ('33333333-3333-3333-3333-333333333333', '33333333-3333-3333-3333-333333333333', 'Yossi Israeli', '0507654321', 'Israeli Ltd.', 'customer', '972507654321'),
+  ('44444444-4444-4444-4444-444444444444', '44444444-4444-4444-4444-444444444444', 'Michal Avraham', '0503456789', 'Avraham & Partners', 'customer', '972503456789'),
+  ('55555555-5555-5555-5555-555555555555', '55555555-5555-5555-5555-555555555555', 'Attorney Ron Mizrahi', '0502345678', 'Mizrahi Firm', 'supplier', '972502345678'),
+  ('66666666-6666-6666-6666-666666666666', '66666666-6666-6666-6666-666666666666', 'System Administrator', '0501111222', 'System Company', 'admin', '972501111222')
 ON CONFLICT (id) DO NOTHING;
 
 -- Insert sample lawyers (suppliers in this context)
 INSERT INTO public.lawyers (id, profile_id, specializations, years_experience, hourly_rate, rating, bio, law_firm, location, license_number, verification_status, is_active, availability_status, total_cases) VALUES
-  ('aaaaaaaa-1111-1111-1111-111111111111', '11111111-1111-1111-1111-111111111111', ARRAY['דיני משפחה', 'דיני עבודה'], 15, 500, 4.8, 'עורך דין מנוסה המתמחה בדיני משפחה ועבודה', 'משרד עורכי דין כהן ושות', 'תל אביב', '12345', 'verified', true, 'available', 45),
-  ('bbbbbbbb-2222-2222-2222-222222222222', '22222222-2222-2222-2222-222222222222', ARRAY['דיני חוזים', 'דיני נזקין'], 12, 450, 4.6, 'מומחית בדיני חוזים ונזקין', 'משרד לוי ושות', 'חיפה', '67890', 'verified', true, 'available', 38),
-  ('cccccccc-3333-3333-3333-333333333333', '55555555-5555-5555-5555-555555555555', ARRAY['דיני חברות', 'דיני מקרקעין'], 8, 400, 4.4, 'עורך דין צעיר ומבטיח', 'משרד מזרחי', 'ירושלים', '54321', 'verified', true, 'available', 22)
+  ('aaaaaaaa-1111-1111-1111-111111111111', '11111111-1111-1111-1111-111111111111', ARRAY['Family Law', 'Labor Law'], 15, 500, 4.8, 'Experienced lawyer specializing in family and labor law', 'Cohen & Partners Law Firm', 'Tel Aviv', '12345', 'verified', true, 'available', 45),
+  ('bbbbbbbb-2222-2222-2222-222222222222', '22222222-2222-2222-2222-222222222222', ARRAY['Contract Law', 'Tort Law'], 12, 450, 4.6, 'Expert in contract and tort law', 'Levy & Partners', 'Haifa', '67890', 'verified', true, 'available', 38),
+  ('cccccccc-3333-3333-3333-333333333333', '55555555-5555-5555-5555-555555555555', ARRAY['Corporate Law', 'Real Estate Law'], 8, 400, 4.4, 'Promising young lawyer', 'Mizrahi Firm', 'Jerusalem', '54321', 'verified', true, 'available', 22)
 ON CONFLICT (id) DO NOTHING;
 
 -- Insert sample leads
 INSERT INTO public.leads (id, customer_name, customer_phone, customer_email, legal_category, case_description, urgency_level, estimated_budget, preferred_location, source, status, assigned_lawyer_id) VALUES
-  ('eeeeeeee-1111-1111-1111-111111111111', 'אמיר כהן', '0501111111', 'amir@example.com', 'דיני משפחה', 'תיק גירושין מורכב עם ילדים קטינים', 'high', 15000, 'תל אביב', 'website', 'assigned', 'aaaaaaaa-1111-1111-1111-111111111111'),
-  ('eeeeeeee-2222-2222-2222-222222222222', 'רחל דוד', '0502222222', 'rachel@example.com', 'דיני עבודה', 'פיטורים לא חוקיים מהעבודה', 'medium', 8000, 'חיפה', 'referral', 'new', NULL),
-  ('eeeeeeee-3333-3333-3333-333333333333', 'משה לוי', '0503333333', 'moshe@example.com', 'דיני נזקין', 'תאונת דרכים עם נזקים כבדים', 'high', 25000, 'תל אביב', 'google', 'converted', 'bbbbbbbb-2222-2222-2222-222222222222'),
-  ('eeeeeeee-4444-4444-4444-444444444444', 'נועה רוזן', '0504444444', 'noa@example.com', 'דיני חוזים', 'הפרת חוזה עסקי', 'low', 5000, 'ירושלים', 'website', 'new', NULL)
+  ('eeeeeeee-1111-1111-1111-111111111111', 'Amir Cohen', '0501111111', 'amir@example.com', 'Family Law', 'Complex divorce case with minor children', 'high', 15000, 'Tel Aviv', 'website', 'assigned', 'aaaaaaaa-1111-1111-1111-111111111111'),
+  ('eeeeeeee-2222-2222-2222-222222222222', 'Rachel David', '0502222222', 'rachel@example.com', 'Labor Law', 'Unlawful termination from work', 'medium', 8000, 'Haifa', 'referral', 'new', NULL),
+  ('eeeeeeee-3333-3333-3333-333333333333', 'Moshe Levy', '0503333333', 'moshe@example.com', 'Tort Law', 'Car accident with heavy damages', 'high', 25000, 'Tel Aviv', 'google', 'converted', 'bbbbbbbb-2222-2222-2222-222222222222'),
+  ('eeeeeeee-4444-4444-4444-444444444444', 'Noa Rosen', '0504444444', 'noa@example.com', 'Contract Law', 'Business contract breach', 'low', 5000, 'Jerusalem', 'website', 'new', NULL)
 ON CONFLICT (id) DO NOTHING;
 
 -- Insert sample cases
 INSERT INTO public.cases (id, title, client_id, legal_category, status, priority, estimated_budget, assigned_lawyer_id, notes, opened_at) VALUES
-  ('dddddddd-1111-1111-1111-111111111111', 'תיק גירושין - אמיר כהן', '33333333-3333-3333-3333-333333333333', 'דיני משפחה', 'open', 'high', 15000, 'aaaaaaaa-1111-1111-1111-111111111111', 'תיק מורכב עם ילדים', '2024-01-15 10:00:00+00'),
-  ('dddddddd-2222-2222-2222-222222222222', 'תאונת דרכים - משה לוי', '44444444-4444-4444-4444-444444444444', 'דיני נזקין', 'open', 'high', 25000, 'bbbbbbbb-2222-2222-2222-222222222222', 'נזקים כבדים ונכות', '2024-01-20 14:30:00+00'),
-  ('dddddddd-3333-3333-3333-333333333333', 'הפרת חוזה - חברת ABC', '33333333-3333-3333-3333-333333333333', 'דיני חוזים', 'closed', 'medium', 12000, 'cccccccc-3333-3333-3333-333333333333', 'הושג פשר', '2023-12-01 09:00:00+00')
+  ('dddddddd-1111-1111-1111-111111111111', 'Divorce Case - Amir Cohen', '33333333-3333-3333-3333-333333333333', 'Family Law', 'open', 'high', 15000, 'aaaaaaaa-1111-1111-1111-111111111111', 'Complex case with children', '2024-01-15 10:00:00+00'),
+  ('dddddddd-2222-2222-2222-222222222222', 'Car Accident - Moshe Levy', '44444444-4444-4444-4444-444444444444', 'Tort Law', 'open', 'high', 25000, 'bbbbbbbb-2222-2222-2222-222222222222', 'Severe damages and disability', '2024-01-20 14:30:00+00'),
+  ('dddddddd-3333-3333-3333-333333333333', 'Contract Breach - ABC Company', '33333333-3333-3333-3333-333333333333', 'Contract Law', 'closed', 'medium', 12000, 'cccccccc-3333-3333-3333-333333333333', 'Settlement reached', '2023-12-01 09:00:00+00')
 ON CONFLICT (id) DO NOTHING;
 
 -- Insert sample events
 INSERT INTO public.events (id, title, start_time, end_time, client_id, case_id, lawyer_id, description) VALUES
-  ('ffffffff-1111-1111-1111-111111111111', 'פגישה עם לקוח - אמיר כהן', '2024-02-01 10:00:00+00', '2024-02-01 11:30:00+00', '33333333-3333-3333-3333-333333333333', 'dddddddd-1111-1111-1111-111111111111', 'aaaaaaaa-1111-1111-1111-111111111111', 'פגישת התייעצות ראשונה'),
-  ('ffffffff-2222-2222-2222-222222222222', 'דיון בבית משפט', '2024-02-05 09:00:00+00', '2024-02-05 12:00:00+00', '44444444-4444-4444-4444-444444444444', 'dddddddd-2222-2222-2222-222222222222', 'bbbbbbbb-2222-2222-2222-222222222222', 'דיון בתביעת נזקין'),
-  ('ffffffff-3333-3333-3333-333333333333', 'פגישת צוות', '2024-02-03 16:00:00+00', '2024-02-03 17:00:00+00', NULL, NULL, 'aaaaaaaa-1111-1111-1111-111111111111', 'סקירת תיקים שוטפים')
+  ('ffffffff-1111-1111-1111-111111111111', 'Meeting with Client - Amir Cohen', '2024-02-01 10:00:00+00', '2024-02-01 11:30:00+00', '33333333-3333-3333-3333-333333333333', 'dddddddd-1111-1111-1111-111111111111', 'aaaaaaaa-1111-1111-1111-111111111111', 'Initial consultation meeting'),
+  ('ffffffff-2222-2222-2222-222222222222', 'Court hearing', '2024-02-05 09:00:00+00', '2024-02-05 12:00:00+00', '44444444-4444-4444-4444-444444444444', 'dddddddd-2222-2222-2222-222222222222', 'bbbbbbbb-2222-2222-2222-222222222222', 'Tort lawsuit hearing'),
+  ('ffffffff-3333-3333-3333-333333333333', 'Team meeting', '2024-02-03 16:00:00+00', '2024-02-03 17:00:00+00', NULL, NULL, 'aaaaaaaa-1111-1111-1111-111111111111', 'Review of ongoing cases')
 ON CONFLICT (id) DO NOTHING;
 
 -- Insert sample lawyer scores

--- a/supabase/migrations/20250730205220_0e92a8e2-4ec7-4d09-98a1-d09f6cb78843.sql
+++ b/supabase/migrations/20250730205220_0e92a8e2-4ec7-4d09-98a1-d09f6cb78843.sql
@@ -1,31 +1,31 @@
 -- Create sample data for authentication testing
 -- Insert sample lawyers (profiles first)
 INSERT INTO public.profiles (user_id, full_name, role) VALUES 
-  ('11111111-1111-1111-1111-111111111111', 'עו"ד דני כהן', 'lawyer'),
-  ('22222222-2222-2222-2222-222222222222', 'עו"ד שרה לוי', 'lawyer'),
-  ('33333333-3333-3333-3333-333333333333', 'עו"ד מיכאל רוזן', 'lawyer')
+  ('11111111-1111-1111-1111-111111111111', 'Attorney Danny Cohen', 'lawyer'),
+  ('22222222-2222-2222-2222-222222222222', 'Attorney Sarah Levy', 'lawyer'),
+  ('33333333-3333-3333-3333-333333333333', 'Attorney Michael Rosen', 'lawyer')
 ON CONFLICT (user_id) DO NOTHING;
 
 -- Insert sample lawyers
 INSERT INTO public.lawyers (id, profile_id, license_number, years_experience, hourly_rate, rating, bio, verification_status, is_active) VALUES 
-  ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', (SELECT id FROM profiles WHERE user_id = '11111111-1111-1111-1111-111111111111'), 'LIC001', 10, 500, 4.8, 'עו"ד מנוסה בדיני משפחה ואישות', 'verified', true),
-  ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', (SELECT id FROM profiles WHERE user_id = '22222222-2222-2222-2222-222222222222'), 'LIC002', 8, 450, 4.6, 'עו"ד מתמחה בדיני עבודה וביטוח לאומי', 'verified', true),
-  ('cccccccc-cccc-cccc-cccc-cccccccccccc', (SELECT id FROM profiles WHERE user_id = '33333333-3333-3333-3333-333333333333'), 'LIC003', 15, 600, 4.9, 'עו"ד בכיר בדיני נזיקין ותעבורה', 'verified', true)
+  ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', (SELECT id FROM profiles WHERE user_id = '11111111-1111-1111-1111-111111111111'), 'LIC001', 10, 500, 4.8, 'Experienced attorney in family and personal status law', 'verified', true),
+  ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', (SELECT id FROM profiles WHERE user_id = '22222222-2222-2222-2222-222222222222'), 'LIC002', 8, 450, 4.6, 'Attorney specializing in labor law and national insurance', 'verified', true),
+  ('cccccccc-cccc-cccc-cccc-cccccccccccc', (SELECT id FROM profiles WHERE user_id = '33333333-3333-3333-3333-333333333333'), 'LIC003', 15, 600, 4.9, 'Senior attorney in tort and traffic law', 'verified', true)
 ON CONFLICT (id) DO NOTHING;
 
 -- Insert lawyer specializations
 INSERT INTO public.lawyer_specializations (lawyer_id, specialization, experience_years, success_rate) VALUES 
-  ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'דיני משפחה', 10, 95.5),
-  ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'דיני אישות', 8, 92.0),
-  ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', 'דיני עבודה', 8, 89.5),
-  ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', 'ביטוח לאומי', 6, 91.0),
-  ('cccccccc-cccc-cccc-cccc-cccccccccccc', 'דיני נזיקין', 15, 96.5),
-  ('cccccccc-cccc-cccc-cccc-cccccccccccc', 'דיני תעבורה', 12, 94.0)
+  ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'Family Law', 10, 95.5),
+  ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'Personal Status Law', 8, 92.0),
+  ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', 'Labor Law', 8, 89.5),
+  ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', 'National Insurance', 6, 91.0),
+  ('cccccccc-cccc-cccc-cccc-cccccccccccc', 'Tort Law', 15, 96.5),
+  ('cccccccc-cccc-cccc-cccc-cccccccccccc', 'Traffic Law', 12, 94.0)
 ON CONFLICT (id) DO NOTHING;
 
 -- Insert sample leads for testing
 INSERT INTO public.leads (id, customer_name, customer_phone, customer_email, legal_category, case_description, estimated_budget) VALUES 
-  ('dddddddd-dddd-dddd-dddd-dddddddddddd', 'יוסי אברהם', '0501234567', 'yossi@example.com', 'דיני משפחה', 'בקשה לגירושין בהסכמה', 15000),
-  ('eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee', 'רחל דוד', '0509876543', 'rachel@example.com', 'דיני עבודה', 'פיטורים לא חוקיים', 20000),
-  ('ffffffff-ffff-ffff-ffff-ffffffffffff', 'משה יוסף', '0507654321', 'moshe@example.com', 'דיני נזיקין', 'תאונת דרכים עם נזק חמור', 50000)
+  ('dddddddd-dddd-dddd-dddd-dddddddddddd', 'Yossi Avraham', '0501234567', 'yossi@example.com', 'Family Law', 'Request for consensual divorce', 15000),
+  ('eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee', 'Rachel David', '0509876543', 'rachel@example.com', 'Labor Law', 'Unlawful termination', 20000),
+  ('ffffffff-ffff-ffff-ffff-ffffffffffff', 'Moshe Yosef', '0507654321', 'moshe@example.com', 'Tort Law', 'Car accident with severe damage', 50000)
 ON CONFLICT (id) DO NOTHING;

--- a/supabase/migrations/20250730205520_179204c3-d827-4ec0-9c4d-ada963b200da.sql
+++ b/supabase/migrations/20250730205520_179204c3-d827-4ec0-9c4d-ada963b200da.sql
@@ -1,30 +1,30 @@
 -- First check what roles are allowed, then add sample data with correct roles
 INSERT INTO public.profiles (user_id, full_name, role) VALUES 
-  ('11111111-1111-1111-1111-111111111111', 'עו"ד דני כהן', 'customer'),
-  ('22222222-2222-2222-2222-222222222222', 'עו"ד שרה לוי', 'customer'),
-  ('33333333-3333-3333-3333-333333333333', 'עו"ד מיכאל רוזן', 'customer')
+  ('11111111-1111-1111-1111-111111111111', 'Attorney Danny Cohen', 'customer'),
+  ('22222222-2222-2222-2222-222222222222', 'Attorney Sarah Levy', 'customer'),
+  ('33333333-3333-3333-3333-333333333333', 'Attorney Michael Rosen', 'customer')
 ON CONFLICT (user_id) DO NOTHING;
 
 -- Insert sample lawyers
 INSERT INTO public.lawyers (id, profile_id, license_number, years_experience, hourly_rate, rating, bio, verification_status, is_active) VALUES 
-  ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', (SELECT id FROM profiles WHERE user_id = '11111111-1111-1111-1111-111111111111'), 'LIC001', 10, 500, 4.8, 'עו"ד מנוסה בדיני משפחה ואישות', 'verified', true),
-  ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', (SELECT id FROM profiles WHERE user_id = '22222222-2222-2222-2222-222222222222'), 'LIC002', 8, 450, 4.6, 'עו"ד מתמחה בדיני עבודה וביטוח לאומי', 'verified', true),
-  ('cccccccc-cccc-cccc-cccc-cccccccccccc', (SELECT id FROM profiles WHERE user_id = '33333333-3333-3333-3333-333333333333'), 'LIC003', 15, 600, 4.9, 'עו"ד בכיר בדיני נזיקין ותעבורה', 'verified', true)
+  ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', (SELECT id FROM profiles WHERE user_id = '11111111-1111-1111-1111-111111111111'), 'LIC001', 10, 500, 4.8, 'Experienced attorney in family and personal status law', 'verified', true),
+  ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', (SELECT id FROM profiles WHERE user_id = '22222222-2222-2222-2222-222222222222'), 'LIC002', 8, 450, 4.6, 'Attorney specializing in labor law and national insurance', 'verified', true),
+  ('cccccccc-cccc-cccc-cccc-cccccccccccc', (SELECT id FROM profiles WHERE user_id = '33333333-3333-3333-3333-333333333333'), 'LIC003', 15, 600, 4.9, 'Senior attorney in tort and traffic law', 'verified', true)
 ON CONFLICT (id) DO NOTHING;
 
 -- Insert lawyer specializations
 INSERT INTO public.lawyer_specializations (lawyer_id, specialization, experience_years, success_rate) VALUES 
-  ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'דיני משפחה', 10, 95.5),
-  ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'דיני אישות', 8, 92.0),
-  ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', 'דיני עבודה', 8, 89.5),
-  ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', 'ביטוח לאומי', 6, 91.0),
-  ('cccccccc-cccc-cccc-cccc-cccccccccccc', 'דיני נזיקין', 15, 96.5),
-  ('cccccccc-cccc-cccc-cccc-cccccccccccc', 'דיני תעבורה', 12, 94.0)
+  ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'Family Law', 10, 95.5),
+  ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'Personal Status Law', 8, 92.0),
+  ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', 'Labor Law', 8, 89.5),
+  ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', 'National Insurance', 6, 91.0),
+  ('cccccccc-cccc-cccc-cccc-cccccccccccc', 'Tort Law', 15, 96.5),
+  ('cccccccc-cccc-cccc-cccc-cccccccccccc', 'Traffic Law', 12, 94.0)
 ON CONFLICT (id) DO NOTHING;
 
 -- Insert sample leads for testing
 INSERT INTO public.leads (id, customer_name, customer_phone, customer_email, legal_category, case_description, estimated_budget) VALUES 
-  ('dddddddd-dddd-dddd-dddd-dddddddddddd', 'יוסי אברהם', '0501234567', 'yossi@example.com', 'דיני משפחה', 'בקשה לגירושין בהסכמה', 15000),
-  ('eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee', 'רחל דוד', '0509876543', 'rachel@example.com', 'דיני עבודה', 'פיטורים לא חוקיים', 20000),
-  ('ffffffff-ffff-ffff-ffff-ffffffffffff', 'משה יוסף', '0507654321', 'moshe@example.com', 'דיני נזיקין', 'תאונת דרכים עם נזק חמור', 50000)
+  ('dddddddd-dddd-dddd-dddd-dddddddddddd', 'Yossi Avraham', '0501234567', 'yossi@example.com', 'Family Law', 'Request for consensual divorce', 15000),
+  ('eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee', 'Rachel David', '0509876543', 'rachel@example.com', 'Labor Law', 'Unlawful termination', 20000),
+  ('ffffffff-ffff-ffff-ffff-ffffffffffff', 'Moshe Yosef', '0507654321', 'moshe@example.com', 'Tort Law', 'Car accident with severe damage', 50000)
 ON CONFLICT (id) DO NOTHING;

--- a/supabase/migrations/20250803114050_c95aea70-cdb0-4839-be0e-36661a591057.sql
+++ b/supabase/migrations/20250803114050_c95aea70-cdb0-4839-be0e-36661a591057.sql
@@ -109,7 +109,7 @@ BEGIN
     created_at,
     updated_at
   ) VALUES (
-    'טיפול ב' || v_lead.legal_category || ' עבור ' || v_lead.customer_name,
+    'Handling ' || v_lead.legal_category || ' for ' || v_lead.customer_name,
     v_client_id,
     v_lead.assigned_lawyer_id,
     v_lead.legal_category,


### PR DESCRIPTION
## Summary
- Replace Hebrew sample data and comments in multiple migration files with English equivalents.
- Update legal category seeds to use English names and descriptions.

## Testing
- `npx supabase db reset --no-seed --yes` *(failed: auth has invalid keys: port, refresh_token_rotation_enabled)*

------
https://chatgpt.com/codex/tasks/task_e_6899d0ccd02483238bf87ecc553cd156