### PR TITLE
refactor: translate hooks to english

### DIFF
--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -38,7 +38,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         setUser(session?.user ?? null);
         setLoading(false);
 
-        // Create profile for new users - מונע לולאות
+        // Create profile for new users - prevents loops
         if (event === 'SIGNED_IN' && session?.user && !user) {
           setTimeout(() => {
             if (isMounted) {
@@ -61,7 +61,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       isMounted = false;
       subscription.unsubscribe();
     };
-  }, []); // רק פעם אחת בהתחלה
+  }, []); // run only once at initialization
 
   const createUserProfile = async (user: User) => {
     try {
@@ -121,26 +121,26 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       });
 
       if (error) {
-        let errorMessage = "אירעה שגיאה ברישום. אנא נסה שוב.";
-        
+        let errorMessage = "An error occurred during registration. Please try again.";
+
         if (error.message === 'User already registered') {
-          errorMessage = "המשתמש כבר רשום במערכת";
+          errorMessage = "User is already registered";
         } else if (error.message.includes('Password')) {
-          errorMessage = "הסיסמה חייבת להכיל לפחות 6 תווים";
+          errorMessage = "Password must be at least 6 characters";
         } else if (error.message.includes('Email')) {
-          errorMessage = "כתובת האימייל לא תקינה";
+          errorMessage = "Invalid email address";
         }
-        
+
         return { error: { message: errorMessage } };
       }
 
       // User registered successfully
       if (data.user) {
         toast({
-          title: "נרשמת בהצלחה!",
-          description: data.user.email_confirmed_at 
-            ? "ברוך הבא למערכת" 
-            : "בדוק את האימייל שלך לאימות החשבון",
+          title: "Registration successful!",
+          description: data.user.email_confirmed_at
+            ? "Welcome to the system"
+            : "Check your email to verify your account",
         });
       }
 
@@ -151,7 +151,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         description: err instanceof Error ? err.message : String(err),
         variant: 'destructive'
       });
-      return { error: { message: "אירעה שגיאה לא צפויה. אנא נסה שוב." } };
+      return { error: { message: "An unexpected error occurred. Please try again." } };
     }
   };
 
@@ -163,16 +163,16 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
     if (error) {
       toast({
-        title: "שגיאה בהתחברות",
-        description: error.message === 'Invalid login credentials' 
-          ? "פרטי התחברות שגויים" 
-          : "אירעה שגיאה בהתחברות. אנא נסה שוב.",
+        title: "Sign-in error",
+        description: error.message === 'Invalid login credentials'
+          ? "Incorrect login details"
+          : "An error occurred during sign-in. Please try again.",
         variant: "destructive",
       });
     } else {
       toast({
-        title: "התחברות מוצלחת",
-        description: "ברוך הבא למערכת",
+        title: "Signed in successfully",
+        description: "Welcome to the system",
       });
     }
 
@@ -183,8 +183,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     const { error } = await supabase.auth.signOut();
     if (!error) {
       toast({
-        title: "התנתקת בהצלחה",
-        description: "להתראות!",
+        title: "Signed out successfully",
+        description: "Goodbye!",
       });
     }
   };

--- a/src/hooks/useCalendar.ts
+++ b/src/hooks/useCalendar.ts
@@ -76,10 +76,10 @@ export const useCalendar = () => {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['events'] });
-      toast({ title: 'אירוע חדש נוצר בהצלחה' });
+      toast({ title: 'Event created successfully' });
     },
     onError: (error) => {
-      toast({ title: 'שגיאה ביצירת אירוע', variant: 'destructive', description: error instanceof Error ? error.message : String(error) });
+      toast({ title: 'Error creating event', variant: 'destructive', description: error instanceof Error ? error.message : String(error) });
     }
   });
 
@@ -97,10 +97,10 @@ export const useCalendar = () => {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['events'] });
-      toast({ title: 'האירוע עודכן בהצלחה' });
+      toast({ title: 'Event updated successfully' });
     },
     onError: () => {
-      toast({ title: 'שגיאה בעדכון האירוע', variant: 'destructive' });
+      toast({ title: 'Error updating event', variant: 'destructive' });
     }
   });
 
@@ -115,10 +115,10 @@ export const useCalendar = () => {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['events'] });
-      toast({ title: 'האירוע נמחק בהצלחה' });
+      toast({ title: 'Event deleted successfully' });
     },
     onError: () => {
-      toast({ title: 'שגיאה במחיקת האירוע', variant: 'destructive' });
+      toast({ title: 'Error deleting event', variant: 'destructive' });
     }
   });
 

--- a/src/hooks/useCases.ts
+++ b/src/hooks/useCases.ts
@@ -54,10 +54,10 @@ export const useCases = () => {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['cases'] });
-      toast({ title: 'תיק חדש נוצר בהצלחה' });
+      toast({ title: 'Case created successfully' });
     },
     onError: (error) => {
-      toast({ title: 'שגיאה ביצירת תיק', variant: 'destructive', description: error instanceof Error ? error.message : String(error) });
+      toast({ title: 'Error creating case', variant: 'destructive', description: error instanceof Error ? error.message : String(error) });
     }
   });
 
@@ -75,10 +75,10 @@ export const useCases = () => {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['cases'] });
-      toast({ title: 'התיק עודכן בהצלחה' });
+      toast({ title: 'Case updated successfully' });
     },
     onError: () => {
-      toast({ title: 'שגיאה בעדכון התיק', variant: 'destructive' });
+      toast({ title: 'Error updating case', variant: 'destructive' });
     }
   });
 
@@ -96,10 +96,10 @@ export const useCases = () => {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['cases'] });
-      toast({ title: 'התיק נסגר בהצלחה' });
+      toast({ title: 'Case closed successfully' });
     },
     onError: () => {
-      toast({ title: 'שגיאה בסגירת התיק', variant: 'destructive' });
+      toast({ title: 'Error closing case', variant: 'destructive' });
     }
   });
 

--- a/src/hooks/useClients.ts
+++ b/src/hooks/useClients.ts
@@ -64,10 +64,10 @@ export const useClients = () => {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['clients'] });
-      toast({ title: 'לקוח חדש נוסף בהצלחה' });
+      toast({ title: 'Client added successfully' });
     },
     onError: (error) => {
-      toast({ title: 'שגיאה בהוספת לקוח', variant: 'destructive', description: error instanceof Error ? error.message : String(error) });
+      toast({ title: 'Error adding client', variant: 'destructive', description: error instanceof Error ? error.message : String(error) });
     }
   });
 
@@ -85,10 +85,10 @@ export const useClients = () => {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['clients'] });
-      toast({ title: 'פרטי הלקוח עודכנו בהצלחה' });
+      toast({ title: 'Client details updated successfully' });
     },
     onError: () => {
-      toast({ title: 'שגיאה בעדכון פרטי הלקוח', variant: 'destructive' });
+      toast({ title: 'Error updating client details', variant: 'destructive' });
     }
   });
 
@@ -103,10 +103,10 @@ export const useClients = () => {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['clients'] });
-      toast({ title: 'הלקוח נמחק בהצלחה' });
+      toast({ title: 'Client deleted successfully' });
     },
     onError: () => {
-      toast({ title: 'שגיאה במחיקת הלקוח', variant: 'destructive' });
+      toast({ title: 'Error deleting client', variant: 'destructive' });
     }
   });
 

--- a/src/hooks/useContracts.ts
+++ b/src/hooks/useContracts.ts
@@ -72,10 +72,10 @@ export const useContracts = () => {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['digital-contracts'] });
-      toast({ title: 'חוזה דיגיטלי נוצר בהצלחה' });
+      toast({ title: 'Digital contract created successfully' });
     },
     onError: (error) => {
-      toast({ title: 'שגיאה ביצירת החוזה', variant: 'destructive', description: error instanceof Error ? error.message : String(error) });
+      toast({ title: 'Error creating contract', variant: 'destructive', description: error instanceof Error ? error.message : String(error) });
     }
   });
 
@@ -122,10 +122,10 @@ export const useContracts = () => {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['digital-contracts'] });
-      toast({ title: 'החוזה נחתם בהצלחה' });
+      toast({ title: 'Contract signed successfully' });
     },
     onError: () => {
-      toast({ title: 'שגיאה בחתימת החוזה', variant: 'destructive' });
+      toast({ title: 'Error signing contract', variant: 'destructive' });
     }
   });
 
@@ -143,10 +143,10 @@ export const useContracts = () => {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['digital-contracts'] });
-      toast({ title: 'החוזה עודכן בהצלחה' });
+      toast({ title: 'Contract updated successfully' });
     },
     onError: () => {
-      toast({ title: 'שגיאה בעדכון החוזה', variant: 'destructive' });
+      toast({ title: 'Error updating contract', variant: 'destructive' });
     }
   });
 

--- a/src/hooks/useDeposits.ts
+++ b/src/hooks/useDeposits.ts
@@ -39,7 +39,7 @@ export const useLeadDeposits = () => {
     mutationFn: async (newDeposit: NewLeadDeposit) => {
       const { data, error } = await supabase
         .from('deposits')
-        .insert(newDeposit as any)
+        .insert(newDeposit)
         .select()
         .single();
       
@@ -48,22 +48,23 @@ export const useLeadDeposits = () => {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['deposits'] });
-      toast({ title: 'פיקדון נוצר בהצלחה' });
+      toast({ title: 'Deposit created successfully' });
     },
     onError: (error) => {
-      toast({ 
-        title: 'שגיאה ביצירת פיקדון', 
-        variant: 'destructive', 
-        description: error instanceof Error ? error.message : String(error) 
+      toast({
+        title: 'Error creating deposit',
+        variant: 'destructive',
+        description: error instanceof Error ? error.message : String(error)
       });
     }
   });
 
   const updateDeposit = useMutation({
     mutationFn: async ({ id, values }: { id: string; values: Partial<LeadDeposit> }) => {
+      const updateData: Partial<LeadDeposit> = { ...values, updated_at: new Date().toISOString() };
       const { data, error } = await supabase
         .from('deposits')
-        .update({ ...values, updated_at: new Date().toISOString() } as any)
+        .update(updateData)
         .eq('id', id)
         .select()
         .single();
@@ -73,10 +74,10 @@ export const useLeadDeposits = () => {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['deposits'] });
-      toast({ title: 'הפיקדון עודכן בהצלחה' });
+      toast({ title: 'Deposit updated successfully' });
     },
     onError: () => {
-      toast({ title: 'שגיאה בעדכון הפיקדון', variant: 'destructive' });
+      toast({ title: 'Error updating deposit', variant: 'destructive' });
     }
   });
 

--- a/src/hooks/useLeads.ts
+++ b/src/hooks/useLeads.ts
@@ -30,17 +30,17 @@ export const useLeads = () => {
     try {
       const parsed = JSON.parse(text);
       return {
-        legal_category: parsed.legal_category || 'אזרחי',
+        legal_category: parsed.legal_category || 'civil',
         urgency_level: parsed.urgency_level || 'medium'
       };
     } catch {
-      return { legal_category: 'אזרחי', urgency_level: 'medium' };
+      return { legal_category: 'civil', urgency_level: 'medium' };
     }
   };
 
   const addLead = useMutation({
     mutationFn: async (newLead: Partial<NewLead>) => {
-      let classification = { legal_category: 'אזרחי', urgency_level: 'medium' };
+      let classification = { legal_category: 'civil', urgency_level: 'medium' };
       
       if (newLead.case_description) {
         try {
@@ -80,7 +80,7 @@ export const useLeads = () => {
     },
     onSuccess: async (data) => {
       queryClient.invalidateQueries({ queryKey: ['leads'] });
-      toast({ title: 'ליד חדש נוצר בהצלחה' });
+      toast({ title: 'Lead created successfully' });
       
       // Trigger automated pipeline
       try {
@@ -88,12 +88,12 @@ export const useLeads = () => {
           body: { leadId: data.id }
         });
         toast({
-          title: 'Pipeline אוטומטי הופעל עבור ליד',
+          title: 'Automated pipeline triggered for lead',
           description: String(data.id)
         });
       } catch (error) {
         toast({
-          title: 'Pipeline אוטומטי נכשל',
+          title: 'Automated pipeline failed',
           description: error instanceof Error ? error.message : String(error),
           variant: 'destructive'
         });
@@ -103,7 +103,7 @@ export const useLeads = () => {
           try {
             await sendWhatsAppTextMessage(
               data.customer_phone,
-              `שלום ${data.customer_name}, בקשתך התקבלה במערכת ואנו נחזור אליך בהקדם. תחום: ${data.legal_category}`
+              `Hello ${data.customer_name}, your request has been received and we will get back to you soon. Field: ${data.legal_category}`
             );
           } catch (error) {
             toast({
@@ -116,7 +116,7 @@ export const useLeads = () => {
       }
     },
     onError: (error) => {
-      toast({ title: 'שגיאה ביצירת ליד', variant: 'destructive', description: error instanceof Error ? error.message : String(error) });
+      toast({ title: 'Error creating lead', variant: 'destructive', description: error instanceof Error ? error.message : String(error) });
     }
   });
 
@@ -134,10 +134,10 @@ export const useLeads = () => {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['leads'] });
-      toast({ title: 'הליד עודכן בהצלחה' });
+      toast({ title: 'Lead updated successfully' });
     },
     onError: () => {
-      toast({ title: 'שגיאה בעדכון הליד', variant: 'destructive' });
+      toast({ title: 'Error updating lead', variant: 'destructive' });
     }
   });
 
@@ -166,7 +166,7 @@ export const useLeads = () => {
         .insert({
           client_id: client.id,
           assigned_lawyer_id: lead.assigned_lawyer_id,
-          title: `טיפול ב${lead.legal_category} עבור ${lead.customer_name}`,
+          title: `Handling ${lead.legal_category} for ${lead.customer_name}`,
           legal_category: lead.legal_category,
           estimated_budget: lead.estimated_budget,
           status: 'open',
@@ -193,16 +193,16 @@ export const useLeads = () => {
       queryClient.invalidateQueries({ queryKey: ['leads'] });
       queryClient.invalidateQueries({ queryKey: ['clients'] });
       queryClient.invalidateQueries({ queryKey: ['cases'] });
-      toast({ 
-        title: 'הליד הומר ללקוח בהצלחה',
-        description: `נוצר תיק חדש: ${data.case.title}`
+      toast({
+        title: 'Lead converted to client successfully',
+        description: `New case created: ${data.case.title}`
       });
     },
     onError: (error) => {
-      toast({ 
-        title: 'שגיאה בהמרת הליד ללקוח', 
-        variant: 'destructive', 
-        description: error instanceof Error ? error.message : String(error) 
+      toast({
+        title: 'Error converting lead to client',
+        variant: 'destructive',
+        description: error instanceof Error ? error.message : String(error)
       });
     }
   });

--- a/src/hooks/useMatching.ts
+++ b/src/hooks/useMatching.ts
@@ -68,10 +68,10 @@ export const useMatching = () => {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['lawyer-specializations'] });
-      toast.success('התמחות נוספה בהצלחה');
+      toast.success('Specialization added successfully');
     },
     onError: () => {
-      toast.error('שגיאה בהוספת התמחות');
+      toast.error('Error adding specialization');
     }
   });
 
@@ -90,10 +90,10 @@ export const useMatching = () => {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['lawyer-specializations'] });
-      toast.success('התמחות עודכנה בהצלחה');
+      toast.success('Specialization updated successfully');
     },
     onError: () => {
-      toast.error('שגיאה בעדכון התמחות');
+      toast.error('Error updating specialization');
     }
   });
 
@@ -109,10 +109,10 @@ export const useMatching = () => {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['lawyer-specializations'] });
-      toast.success('התמחות נמחקה בהצלחה');
+      toast.success('Specialization deleted successfully');
     },
     onError: () => {
-      toast.error('שגיאה במחיקת התמחות');
+      toast.error('Error deleting specialization');
     }
   });
 

--- a/src/hooks/useMeetings.ts
+++ b/src/hooks/useMeetings.ts
@@ -37,8 +37,8 @@ export const useMeetings = () => {
     onSuccess: async (data) => {
       queryClient.invalidateQueries({ queryKey: ['meetings'] });
       toast({
-        title: "פגישה נקבעה בהצלחה",
-        description: "הפגישה נוספה ליומן",
+        title: "Meeting scheduled successfully",
+        description: "The meeting was added to the calendar",
       });
       
       // Send meeting notifications
@@ -55,7 +55,7 @@ export const useMeetings = () => {
     },
     onError: (error) => {
       toast({
-        title: "שגיאה בקביעת פגישה",
+        title: "Error scheduling meeting",
         description: error.message,
         variant: "destructive",
       });
@@ -77,13 +77,13 @@ export const useMeetings = () => {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['meetings'] });
       toast({
-        title: "פגישה עודכנה בהצלחה",
-        description: "פרטי הפגישה נשמרו",
+        title: "Meeting updated successfully",
+        description: "Meeting details saved",
       });
     },
     onError: (error) => {
       toast({
-        title: "שגיאה בעדכון פגישה",
+        title: "Error updating meeting",
         description: error.message,
         variant: "destructive",
       });
@@ -102,13 +102,13 @@ export const useMeetings = () => {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['meetings'] });
       toast({
-        title: "פגישה בוטלה",
-        description: "הפגישה הוסרה מהיומן",
+        title: "Meeting canceled",
+        description: "The meeting was removed from the calendar",
       });
     },
     onError: (error) => {
       toast({
-        title: "שגיאה בביטול פגישה",
+        title: "Error canceling meeting",
         description: error.message,
         variant: "destructive",
       });

--- a/src/hooks/useQuotes.ts
+++ b/src/hooks/useQuotes.ts
@@ -51,10 +51,10 @@ export const useQuotes = () => {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['quotes'] });
-      toast({ title: 'הצעת מחיר נשלחה בהצלחה' });
+      toast({ title: 'Quote sent successfully' });
     },
     onError: (error) => {
-      toast({ title: 'שגיאה בשליחת הצעת מחיר', variant: 'destructive', description: error instanceof Error ? error.message : String(error) });
+      toast({ title: 'Error sending quote', variant: 'destructive', description: error instanceof Error ? error.message : String(error) });
     }
   });
 
@@ -72,10 +72,10 @@ export const useQuotes = () => {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['quotes'] });
-      toast({ title: 'הצעת מחיר עודכנה בהצלחה' });
+      toast({ title: 'Quote updated successfully' });
     },
     onError: () => {
-      toast({ title: 'שגיאה בעדכון הצעת מחיר', variant: 'destructive' });
+      toast({ title: 'Error updating quote', variant: 'destructive' });
     }
   });
 
@@ -93,10 +93,10 @@ export const useQuotes = () => {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['quotes'] });
-      toast({ title: 'הצעת המחיר אושרה בהצלחה' });
+      toast({ title: 'Quote approved successfully' });
     },
     onError: () => {
-      toast({ title: 'שגיאה באישור הצעת מחיר', variant: 'destructive' });
+      toast({ title: 'Error approving quote', variant: 'destructive' });
     }
   });
 
@@ -114,10 +114,10 @@ export const useQuotes = () => {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['quotes'] });
-      toast({ title: 'הצעת המחיר נדחתה' });
+      toast({ title: 'Quote rejected' });
     },
     onError: () => {
-      toast({ title: 'שגיאה בדחיית הצעת מחיר', variant: 'destructive' });
+      toast({ title: 'Error rejecting quote', variant: 'destructive' });
     }
   });
 

--- a/src/hooks/useRatings.ts
+++ b/src/hooks/useRatings.ts
@@ -45,13 +45,13 @@ export const useRatings = () => {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['ratings'] });
       toast({
-        title: "דירוג נשלח בהצלחה",
-        description: "תודה על המשוב שלך!",
+        title: "Rating submitted successfully",
+        description: "Thank you for your feedback!",
       });
     },
     onError: (error) => {
       toast({
-        title: "שגיאה בשליחת דירוג",
+        title: "Error submitting rating",
         description: error.message,
         variant: "destructive",
       });

--- a/src/hooks/useRole.tsx
+++ b/src/hooks/useRole.tsx
@@ -28,13 +28,13 @@ export function useRole(): UserRoleData {
       return;
     }
 
-    // עיכוב קצר למניעת טעינות מיותרות
+    // Short delay to prevent unnecessary loads
     const timeoutId = setTimeout(() => {
       fetchUserRole();
     }, 100);
 
     return () => clearTimeout(timeoutId);
-  }, [user?.id]); // רק כשה-user id משתנה
+  }, [user?.id]); // only when the user id changes
 
   const fetchUserRole = async () => {
     if (!user?.id) {
@@ -45,7 +45,7 @@ export function useRole(): UserRoleData {
     try {
       setLoading(true);
       
-      // יעיל יותר - רק בקשה אחת לprofiles
+      // More efficient - only one request to profiles
       const { data: profile, error } = await supabase
         .from('profiles')
         .select('role')


### PR DESCRIPTION
## Summary
- replace Hebrew toast messages and defaults with English equivalents across hooks
- adjust lead classification defaults to English
- translate signup/signin notifications to English

## Testing
- `npm run lint` *(fails: Unexpected any, etc)*
- `npx eslint src/hooks`

------
https://chatgpt.com/codex/tasks/task_e_6899d0c1a3988323ac14a1cbdbc637a3