### PR TITLE
Add legal consultation page and backend function with GitHub logging

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,6 +31,7 @@ import RoleDashboard from "./pages/RoleDashboard";
 import SupplierLeads from "./pages/SupplierLeads";
 import CourtDashboard from "./pages/court/CourtDashboard";
 import CourtSessionDetails from "./pages/court/CourtSessionDetails";
+import LegalConsultation from "./pages/LegalConsultation";
 import { RoleBasedRoute } from "./components/RoleBasedRoute";
 
 const App = () => (
@@ -126,6 +127,11 @@ const App = () => (
                             <Route path="/matching" element={
                               <RoleBasedRoute allowedRoles={['lawyer', 'admin']}>
                                 <Matching />
+                              </RoleBasedRoute>
+                            } />
+                            <Route path="/legal-consultation" element={
+                              <RoleBasedRoute allowedRoles={['lawyer', 'admin']}>
+                                <LegalConsultation />
                               </RoleBasedRoute>
                             } />
                             <Route path="/court" element={

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -12,6 +12,7 @@ import {
   Search,
   Shield,
   Package,
+  Gavel,
   LucideIcon,
 } from "lucide-react"
 import { NavLink } from "react-router-dom"
@@ -42,6 +43,7 @@ const getMenuItems = (role: string | null) => {
     { title: "תיקים", url: "/cases", icon: FileText, roles: ["lawyer", "admin", "customer"] },
     { title: "התאמות", url: "/matching", icon: Search, roles: ["lawyer", "admin"] },
     { title: "לוח זמנים", url: "/calendar", icon: Calendar, roles: ["lawyer", "admin", "customer"] },
+    { title: "התייעצות משפטית", url: "/legal-consultation", icon: Gavel, roles: ["lawyer", "admin"] },
     { title: "פורטל לידים", url: "/leads-portal", icon: Package, roles: ["supplier", "admin"] },
     { title: "ניהול מערכת", url: "/admin", icon: Shield, roles: ["admin"] },
   ]

--- a/src/pages/LegalConsultation.tsx
+++ b/src/pages/LegalConsultation.tsx
@@ -1,0 +1,42 @@
+import { useState } from "react"
+import { Button } from "@/components/ui/button"
+import { Textarea } from "@/components/ui/textarea"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+
+const LegalConsultation = () => {
+  const [question, setQuestion] = useState("")
+  const [answer, setAnswer] = useState("")
+  const [loading, setLoading] = useState(false)
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setLoading(true)
+    const res = await fetch("/functions/v1/legal-consultation", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ question })
+    })
+    const data = await res.json()
+    setAnswer(data.answer || "")
+    setLoading(false)
+  }
+
+  return (
+    <div className="p-6 space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>התייעצות משפטית</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={submit} className="space-y-4">
+            <Textarea value={question} onChange={e => setQuestion(e.target.value)} placeholder="כתוב שאלה" />
+            <Button type="submit" disabled={loading}>{loading ? "שולח..." : "שלח"}</Button>
+          </form>
+          {answer && <div className="mt-4 whitespace-pre-wrap">{answer}</div>}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
+export default LegalConsultation

--- a/supabase/functions/legal-consultation/index.ts
+++ b/supabase/functions/legal-consultation/index.ts
@@ -1,0 +1,34 @@
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type"
+}
+
+serve(async req => {
+  if (req.method === "OPTIONS") return new Response(null, { headers: corsHeaders })
+  try {
+    const { question } = await req.json()
+    const apiKey = Deno.env.get("OPENAI_API_KEY")
+    const githubToken = Deno.env.get("GITHUB_TOKEN")
+    const repo = Deno.env.get("GITHUB_REPO")
+    if (!question || !apiKey || !githubToken || !repo) {
+      return new Response(JSON.stringify({ error: "missing" }), { status: 400, headers: { ...corsHeaders, "Content-Type": "application/json" } })
+    }
+    const aiResponse = await fetch("https://api.openai.com/v1/chat/completions", {
+      method: "POST",
+      headers: { Authorization: `Bearer ${apiKey}`, "Content-Type": "application/json" },
+      body: JSON.stringify({ model: "gpt-4o-mini", messages: [{ role: "system", content: "Provide brief legal guidance" }, { role: "user", content: question }], max_tokens: 300 })
+    })
+    const aiData = await aiResponse.json()
+    const answer = aiData.choices?.[0]?.message?.content ?? ""
+    await fetch(`https://api.github.com/repos/${repo}/issues`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${githubToken}`, Accept: "application/vnd.github+json" },
+      body: JSON.stringify({ title: question.slice(0, 50), body: `Q: ${question}\nA: ${answer}` })
+    })
+    return new Response(JSON.stringify({ answer }), { headers: { ...corsHeaders, "Content-Type": "application/json" } })
+  } catch (e) {
+    return new Response(JSON.stringify({ error: e.message }), { status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" } })
+  }
+})


### PR DESCRIPTION
## Summary
- add legal consultation page with question form and answer output
- create legal-consultation function calling GPT and logging to GitHub
- expose legal consultation in sidebar and router for admins and lawyers

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any. Specify a different type; React Hook useEffect has a missing dependency)*
- `npx eslint src/pages/LegalConsultation.tsx src/components/AppSidebar.tsx src/App.tsx supabase/functions/legal-consultation/index.ts`

------
https://chatgpt.com/codex/tasks/task_e_6899d0af24688323b8384f9bffba6d69