### PR TITLE
Translate sidebar titles and add court link

### DIFF
--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -12,6 +12,7 @@ import {
   Search,
   Shield,
   Package,
+  Gavel,
   LucideIcon,
 } from "lucide-react"
 import { NavLink } from "react-router-dom"
@@ -35,22 +36,23 @@ interface AppSidebarProps {
 const getMenuItems = (role: string | null) => {
   // מפתחות ייחודיים עם prefix לכל קטגוריה
   const allMenuItems: MenuItem[] = [
-    { title: "דשבורד", url: "/dashboard", icon: Home, roles: ["admin", "lawyer", "customer", "supplier"] },
-    { title: "לידים", url: "/leads", icon: Target, roles: ["lawyer", "admin"] },
-    { title: "לידים", url: "/supplier/leads", icon: Target, roles: ["supplier", "admin"] },
-    { title: "לקוחות", url: "/clients", icon: Users, roles: ["lawyer", "admin"] },
-    { title: "תיקים", url: "/cases", icon: FileText, roles: ["lawyer", "admin", "customer"] },
-    { title: "התאמות", url: "/matching", icon: Search, roles: ["lawyer", "admin"] },
-    { title: "לוח זמנים", url: "/calendar", icon: Calendar, roles: ["lawyer", "admin", "customer"] },
-    { title: "פורטל לידים", url: "/leads-portal", icon: Package, roles: ["supplier", "admin"] },
-    { title: "ניהול מערכת", url: "/admin", icon: Shield, roles: ["admin"] },
+    { title: "Court", url: "/court", icon: Gavel, roles: ["admin", "lawyer"] },
+    { title: "Dashboard", url: "/dashboard", icon: Home, roles: ["admin", "lawyer", "customer", "supplier"] },
+    { title: "Leads", url: "/leads", icon: Target, roles: ["lawyer", "admin"] },
+    { title: "Leads", url: "/supplier/leads", icon: Target, roles: ["supplier", "admin"] },
+    { title: "Clients", url: "/clients", icon: Users, roles: ["lawyer", "admin"] },
+    { title: "Cases", url: "/cases", icon: FileText, roles: ["lawyer", "admin", "customer"] },
+    { title: "Matching", url: "/matching", icon: Search, roles: ["lawyer", "admin"] },
+    { title: "Calendar", url: "/calendar", icon: Calendar, roles: ["lawyer", "admin", "customer"] },
+    { title: "Leads Portal", url: "/leads-portal", icon: Package, roles: ["supplier", "admin"] },
+    { title: "System Management", url: "/admin", icon: Shield, roles: ["admin"] },
   ]
 
   const businessItems: MenuItem[] = [
-    { title: "תשלומים", url: "/payments", icon: CreditCard, roles: ["lawyer", "admin", "customer"] },
-    { title: "עמלות", url: "/commissions", icon: DollarSign, roles: ["lawyer", "admin"] },
-    { title: "דוחות", url: "/reports", icon: BarChart3, roles: ["lawyer", "admin"] },
-    { title: "פיצ'רים", url: "/features", icon: FileText, roles: ["admin"] },
+    { title: "Payments", url: "/payments", icon: CreditCard, roles: ["lawyer", "admin", "customer"] },
+    { title: "Commissions", url: "/commissions", icon: DollarSign, roles: ["lawyer", "admin"] },
+    { title: "Reports", url: "/reports", icon: BarChart3, roles: ["lawyer", "admin"] },
+    { title: "Features", url: "/features", icon: FileText, roles: ["admin"] },
   ]
 
   const mainItems = allMenuItems.filter((item) => !role || item.roles.includes(role))
@@ -82,19 +84,19 @@ export const AppSidebar: React.FC<AppSidebarProps> = ({ open, onOpenChange }) =>
   const content = (
     <div className="h-full w-64 bg-sidebar text-sidebar-foreground p-4 space-y-6" dir="rtl">
       <div className="space-y-2">
-        <h2 className="text-sm font-semibold">ניהול ראשי</h2>
+        <h2 className="text-sm font-semibold">Main Management</h2>
         <nav className="space-y-1">{renderLinks(mainItems)}</nav>
       </div>
 
       <div className="space-y-2">
-        <h2 className="text-sm font-semibold">עסקי ופיננסי</h2>
+        <h2 className="text-sm font-semibold">Business and Finance</h2>
         <nav className="space-y-1">{renderLinks(businessItems)}</nav>
       </div>
 
       <div className="mt-auto space-y-1">
         <NavLink to="/settings" className={({ isActive }) => navCls(isActive)}>
           <Settings className="h-4 w-4 md:h-5 md:w-5 ml-2" />
-          <span className="flex-1">הגדרות</span>
+          <span className="flex-1">Settings</span>
         </NavLink>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Translate sidebar menu and section headings to English
- Add Court navigation item with Gavel icon for admin and lawyer roles

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any in Settings.tsx and create-payment function)*

------
https://chatgpt.com/codex/tasks/task_e_6899d0a43fc4832396c6d30a6a17a5ed