### PR TITLE
Route admin to court dashboard

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -129,12 +129,12 @@ const App = () => (
                               </RoleBasedRoute>
                             } />
                             <Route path="/court" element={
-                              <RoleBasedRoute allowedRoles={['lawyer', 'admin']}>
+                              <RoleBasedRoute allowedRoles={['admin']}>
                                 <CourtDashboard />
                               </RoleBasedRoute>
                             } />
                             <Route path="/court/session/:id" element={
-                              <RoleBasedRoute allowedRoles={['lawyer', 'admin']}>
+                              <RoleBasedRoute allowedRoles={['admin']}>
                                 <CourtSessionDetails />
                               </RoleBasedRoute>
                             } />

--- a/src/pages/RoleDashboard.tsx
+++ b/src/pages/RoleDashboard.tsx
@@ -9,7 +9,7 @@ export default function RoleDashboard() {
 
   useEffect(() => {
     if (loading) return
-    if (role === "admin") navigate("/dashboard/admin", { replace: true })
+    if (role === "admin") navigate("/court", { replace: true })
     else if (role === "lawyer") navigate("/dashboard/lawyer", { replace: true })
     else if (role === "client") navigate("/cases", { replace: true })
     else if (role === "supplier") navigate("/supplier/leads", { replace: true })


### PR DESCRIPTION
## Summary
- Navigate admin users directly to the court dashboard
- Restrict court routes to admin role in router

## Testing
- `npm test -- --run`
- `npm run lint` *(fails: Unexpected any in existing files)*
- `npx eslint src/App.tsx src/pages/RoleDashboard.tsx`


------
https://chatgpt.com/codex/tasks/task_e_6899d0a857208323958c29bd0480a5fb