### PR TITLE
Translate UI text to English and remove RTL layout

### DIFF
--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -31,26 +31,26 @@ interface AppSidebarProps {
   onOpenChange: (open: boolean) => void
 }
 
-// הגדרת פריטי תפריט לפי תפקיד - מבטיח מפתחות ייחודיים
+// Define menu items per role - ensures unique keys
 const getMenuItems = (role: string | null) => {
-  // מפתחות ייחודיים עם prefix לכל קטגוריה
+  // Unique keys with prefix for each category
   const allMenuItems: MenuItem[] = [
-    { title: "דשבורד", url: "/dashboard", icon: Home, roles: ["admin", "lawyer", "customer", "supplier"] },
-    { title: "לידים", url: "/leads", icon: Target, roles: ["lawyer", "admin"] },
-    { title: "לידים", url: "/supplier/leads", icon: Target, roles: ["supplier", "admin"] },
-    { title: "לקוחות", url: "/clients", icon: Users, roles: ["lawyer", "admin"] },
-    { title: "תיקים", url: "/cases", icon: FileText, roles: ["lawyer", "admin", "customer"] },
-    { title: "התאמות", url: "/matching", icon: Search, roles: ["lawyer", "admin"] },
-    { title: "לוח זמנים", url: "/calendar", icon: Calendar, roles: ["lawyer", "admin", "customer"] },
-    { title: "פורטל לידים", url: "/leads-portal", icon: Package, roles: ["supplier", "admin"] },
-    { title: "ניהול מערכת", url: "/admin", icon: Shield, roles: ["admin"] },
+    { title: "Dashboard", url: "/dashboard", icon: Home, roles: ["admin", "lawyer", "customer", "supplier"] },
+    { title: "Leads", url: "/leads", icon: Target, roles: ["lawyer", "admin"] },
+    { title: "Leads", url: "/supplier/leads", icon: Target, roles: ["supplier", "admin"] },
+    { title: "Clients", url: "/clients", icon: Users, roles: ["lawyer", "admin"] },
+    { title: "Cases", url: "/cases", icon: FileText, roles: ["lawyer", "admin", "customer"] },
+    { title: "Matching", url: "/matching", icon: Search, roles: ["lawyer", "admin"] },
+    { title: "Calendar", url: "/calendar", icon: Calendar, roles: ["lawyer", "admin", "customer"] },
+    { title: "Leads Portal", url: "/leads-portal", icon: Package, roles: ["supplier", "admin"] },
+    { title: "System Management", url: "/admin", icon: Shield, roles: ["admin"] },
   ]
 
   const businessItems: MenuItem[] = [
-    { title: "תשלומים", url: "/payments", icon: CreditCard, roles: ["lawyer", "admin", "customer"] },
-    { title: "עמלות", url: "/commissions", icon: DollarSign, roles: ["lawyer", "admin"] },
-    { title: "דוחות", url: "/reports", icon: BarChart3, roles: ["lawyer", "admin"] },
-    { title: "פיצ'רים", url: "/features", icon: FileText, roles: ["admin"] },
+    { title: "Payments", url: "/payments", icon: CreditCard, roles: ["lawyer", "admin", "customer"] },
+    { title: "Commissions", url: "/commissions", icon: DollarSign, roles: ["lawyer", "admin"] },
+    { title: "Reports", url: "/reports", icon: BarChart3, roles: ["lawyer", "admin"] },
+    { title: "Features", url: "/features", icon: FileText, roles: ["admin"] },
   ]
 
   const mainItems = allMenuItems.filter((item) => !role || item.roles.includes(role))
@@ -65,7 +65,7 @@ export const AppSidebar: React.FC<AppSidebarProps> = ({ open, onOpenChange }) =>
   const { mainItems, businessItems } = getMenuItems(role)
 
   const navCls = (active: boolean) =>
-    `flex items-center gap-2 rounded-md p-2 text-right transition-colors ${
+    `flex items-center gap-2 rounded-md p-2 text-left transition-colors ${
       active
         ? "bg-sidebar-accent text-sidebar-accent-foreground font-medium"
         : "hover:bg-sidebar-accent/50"
@@ -74,27 +74,27 @@ export const AppSidebar: React.FC<AppSidebarProps> = ({ open, onOpenChange }) =>
   const renderLinks = (items: MenuItem[]) =>
     items.map(({ title, url, icon: Icon }) => (
       <NavLink key={`${url}-${title}`} to={url} end className={({ isActive }) => navCls(isActive)}>
-        <Icon className="h-4 w-4 md:h-5 md:w-5 ml-2" />
+        <Icon className="h-4 w-4 md:h-5 md:w-5 mr-2" />
         <span className="flex-1">{title}</span>
       </NavLink>
     ))
 
   const content = (
-    <div className="h-full w-64 bg-sidebar text-sidebar-foreground p-4 space-y-6" dir="rtl">
+    <div className="h-full w-64 bg-sidebar text-sidebar-foreground p-4 space-y-6">
       <div className="space-y-2">
-        <h2 className="text-sm font-semibold">ניהול ראשי</h2>
+        <h2 className="text-sm font-semibold">Main Management</h2>
         <nav className="space-y-1">{renderLinks(mainItems)}</nav>
       </div>
 
       <div className="space-y-2">
-        <h2 className="text-sm font-semibold">עסקי ופיננסי</h2>
+        <h2 className="text-sm font-semibold">Business & Finance</h2>
         <nav className="space-y-1">{renderLinks(businessItems)}</nav>
       </div>
 
       <div className="mt-auto space-y-1">
         <NavLink to="/settings" className={({ isActive }) => navCls(isActive)}>
-          <Settings className="h-4 w-4 md:h-5 md:w-5 ml-2" />
-          <span className="flex-1">הגדרות</span>
+          <Settings className="h-4 w-4 md:h-5 md:w-5 mr-2" />
+          <span className="flex-1">Settings</span>
         </NavLink>
       </div>
     </div>
@@ -111,7 +111,7 @@ export const AppSidebar: React.FC<AppSidebarProps> = ({ open, onOpenChange }) =>
   }
 
   return (
-    <aside className="hidden md:block border-l" dir="rtl">
+    <aside className="hidden md:block border-l">
       {content}
     </aside>
   )

--- a/src/components/WorkflowInfographic.tsx
+++ b/src/components/WorkflowInfographic.tsx
@@ -6,68 +6,68 @@ export function WorkflowInfographic() {
   const steps = [
     {
       id: 1,
-      title: "קליטת ליד",
-      subtitle: "WhatsApp / אתר",
+      title: "Lead Intake",
+      subtitle: "WhatsApp / Website",
       icon: MessageSquare,
       color: "bg-primary/10 border-primary/20 text-primary",
-      description: "הליד נקלט דרך WhatsApp או טופס באתר"
+      description: "Lead captured via WhatsApp or website form"
     },
     {
       id: 2,
-      title: "עיבוד AI",
-      subtitle: "ניקוד ומיון",
+      title: "AI Processing",
+      subtitle: "Scoring and Sorting",
       icon: TrendingUp,
       color: "bg-accent/10 border-accent/20 text-accent-foreground",
-      description: "מערכת AI מנתחת ומנקדת את הליד"
+      description: "AI system analyzes and scores the lead"
     },
     {
       id: 3,
-      title: "התאמה",
-      subtitle: "מנוע התאמות",
+      title: "Matching",
+      subtitle: "Matching Engine",
       icon: Users,
       color: "bg-success/10 border-success/20 text-success",
-      description: "מיון עורכי דין מתאימים לפי התמחות ויכולת"
+      description: "Filters suitable lawyers by specialization and capacity"
     },
     {
       id: 4,
-      title: "הצעה",
-      subtitle: "עורך דין מגיב",
+      title: "Proposal",
+      subtitle: "Lawyer Responds",
       icon: FileText,
       color: "bg-warning/10 border-warning/20 text-warning",
-      description: "עורך דין שולח הצעת מחיר ותנאים"
+      description: "Lawyer sends quote and terms"
     },
     {
       id: 5,
-      title: "חוזה",
-      subtitle: "חתימה דיגיטלית",
+      title: "Contract",
+      subtitle: "Digital Signature",
       icon: CheckCircle,
       color: "bg-secondary/10 border-secondary/20 text-secondary-foreground",
-      description: "חתימה על חוזה דיגיטלי"
+      description: "Sign digital contract"
     },
     {
       id: 6,
-      title: "תשלום",
+      title: "Payment",
       subtitle: "WooCommerce",
       icon: CreditCard,
       color: "bg-destructive/10 border-destructive/20 text-destructive",
-      description: "עמלה ותשלום דרך המערכת"
+      description: "Commission and payment through the system"
     },
     {
       id: 7,
-      title: "ביצוע",
-      subtitle: "ניהול פרויקט",
+      title: "Execution",
+      subtitle: "Project Management",
       icon: Award,
       color: "bg-primary-muted/10 border-primary-muted/20 text-primary-muted",
-      description: "מעקב SLA, NPS וביצוע העבודה"
+      description: "Track SLA, NPS and work completion"
     }
   ]
 
   return (
     <Card className="w-full">
       <CardHeader className="text-center">
-        <CardTitle className="text-2xl text-primary">זרימת עבודה - מליד ועד לביצוע</CardTitle>
+        <CardTitle className="text-2xl text-primary">Workflow - From Lead to Completion</CardTitle>
         <p className="text-muted-foreground">
-          תהליך אוטומטי מלא מקליטת הליד ועד לביצוע העבודה והניקוד
+          A fully automated process from lead capture to work completion and scoring
         </p>
       </CardHeader>
       <CardContent className="space-y-4">
@@ -112,14 +112,14 @@ export function WorkflowInfographic() {
         })}
 
         <div className="mt-8 p-4 bg-muted/50 rounded-lg">
-          <h4 className="font-semibold text-primary mb-2">מדדי KPI וניקוד חודשי</h4>
+          <h4 className="font-semibold text-primary mb-2">KPI Metrics and Monthly Scoring</h4>
           <div className="grid grid-cols-2 md:grid-cols-3 gap-2 text-sm text-muted-foreground">
-            <div>📈 אחוז קבלת לידים (60-90%)</div>
-            <div>⏰ עמידה ב-SLA (≥95%)</div>
-            <div>⭐ ציון NPS ממוצע (≥8)</div>
-            <div>💰 יחס החזרים (≤3%)</div>
-            <div>🎯 שעות פרו-בונו (≥20/שנה)</div>
-            <div>🏆 דרגות: ברונזה → כסף → זהב → פלטינום</div>
+            <div>📈 Lead acceptance rate (60-90%)</div>
+            <div>⏰ SLA compliance (≥95%)</div>
+            <div>⭐ Average NPS score (≥8)</div>
+            <div>💰 Refund ratio (≤3%)</div>
+            <div>🎯 Pro bono hours (≥20/year)</div>
+            <div>🏆 Tiers: Bronze → Silver → Gold → Platinum</div>
           </div>
         </div>
       </CardContent>

--- a/src/hooks/useLeads.ts
+++ b/src/hooks/useLeads.ts
@@ -30,17 +30,17 @@ export const useLeads = () => {
     try {
       const parsed = JSON.parse(text);
       return {
-        legal_category: parsed.legal_category || 'אזרחי',
+        legal_category: parsed.legal_category || 'civil',
         urgency_level: parsed.urgency_level || 'medium'
       };
     } catch {
-      return { legal_category: 'אזרחי', urgency_level: 'medium' };
+      return { legal_category: 'civil', urgency_level: 'medium' };
     }
   };
 
   const addLead = useMutation({
     mutationFn: async (newLead: Partial<NewLead>) => {
-      let classification = { legal_category: 'אזרחי', urgency_level: 'medium' };
+      let classification = { legal_category: 'civil', urgency_level: 'medium' };
       
       if (newLead.case_description) {
         try {
@@ -80,7 +80,7 @@ export const useLeads = () => {
     },
     onSuccess: async (data) => {
       queryClient.invalidateQueries({ queryKey: ['leads'] });
-      toast({ title: 'ליד חדש נוצר בהצלחה' });
+      toast({ title: 'Lead created successfully' });
       
       // Trigger automated pipeline
       try {
@@ -88,12 +88,12 @@ export const useLeads = () => {
           body: { leadId: data.id }
         });
         toast({
-          title: 'Pipeline אוטומטי הופעל עבור ליד',
+          title: 'Automatic pipeline triggered for lead',
           description: String(data.id)
         });
       } catch (error) {
         toast({
-          title: 'Pipeline אוטומטי נכשל',
+          title: 'Automatic pipeline failed',
           description: error instanceof Error ? error.message : String(error),
           variant: 'destructive'
         });
@@ -103,7 +103,7 @@ export const useLeads = () => {
           try {
             await sendWhatsAppTextMessage(
               data.customer_phone,
-              `שלום ${data.customer_name}, בקשתך התקבלה במערכת ואנו נחזור אליך בהקדם. תחום: ${data.legal_category}`
+              `Hello ${data.customer_name}, your request has been received and we will get back to you soon. Category: ${data.legal_category}`
             );
           } catch (error) {
             toast({
@@ -116,7 +116,7 @@ export const useLeads = () => {
       }
     },
     onError: (error) => {
-      toast({ title: 'שגיאה ביצירת ליד', variant: 'destructive', description: error instanceof Error ? error.message : String(error) });
+      toast({ title: 'Error creating lead', variant: 'destructive', description: error instanceof Error ? error.message : String(error) });
     }
   });
 
@@ -134,10 +134,10 @@ export const useLeads = () => {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['leads'] });
-      toast({ title: 'הליד עודכן בהצלחה' });
+      toast({ title: 'Lead updated successfully' });
     },
     onError: () => {
-      toast({ title: 'שגיאה בעדכון הליד', variant: 'destructive' });
+      toast({ title: 'Error updating lead', variant: 'destructive' });
     }
   });
 
@@ -166,7 +166,7 @@ export const useLeads = () => {
         .insert({
           client_id: client.id,
           assigned_lawyer_id: lead.assigned_lawyer_id,
-          title: `טיפול ב${lead.legal_category} עבור ${lead.customer_name}`,
+          title: `Handling ${lead.legal_category} for ${lead.customer_name}`,
           legal_category: lead.legal_category,
           estimated_budget: lead.estimated_budget,
           status: 'open',
@@ -194,15 +194,15 @@ export const useLeads = () => {
       queryClient.invalidateQueries({ queryKey: ['clients'] });
       queryClient.invalidateQueries({ queryKey: ['cases'] });
       toast({ 
-        title: 'הליד הומר ללקוח בהצלחה',
-        description: `נוצר תיק חדש: ${data.case.title}`
+        title: 'Lead converted to client successfully',
+        description: `Created new case: ${data.case.title}`
       });
     },
     onError: (error) => {
-      toast({ 
-        title: 'שגיאה בהמרת הליד ללקוח', 
-        variant: 'destructive', 
-        description: error instanceof Error ? error.message : String(error) 
+      toast({
+        title: 'Error converting lead to client',
+        variant: 'destructive',
+        description: error instanceof Error ? error.message : String(error)
       });
     }
   });

--- a/src/hooks/useMatching.ts
+++ b/src/hooks/useMatching.ts
@@ -68,10 +68,10 @@ export const useMatching = () => {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['lawyer-specializations'] });
-      toast.success('התמחות נוספה בהצלחה');
+      toast.success('Specialization added successfully');
     },
     onError: () => {
-      toast.error('שגיאה בהוספת התמחות');
+      toast.error('Error adding specialization');
     }
   });
 
@@ -90,10 +90,10 @@ export const useMatching = () => {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['lawyer-specializations'] });
-      toast.success('התמחות עודכנה בהצלחה');
+      toast.success('Specialization updated successfully');
     },
     onError: () => {
-      toast.error('שגיאה בעדכון התמחות');
+      toast.error('Error updating specialization');
     }
   });
 
@@ -109,10 +109,10 @@ export const useMatching = () => {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['lawyer-specializations'] });
-      toast.success('התמחות נמחקה בהצלחה');
+      toast.success('Specialization deleted successfully');
     },
     onError: () => {
-      toast.error('שגיאה במחיקת התמחות');
+      toast.error('Error deleting specialization');
     }
   });
 

--- a/src/hooks/useRatings.ts
+++ b/src/hooks/useRatings.ts
@@ -45,13 +45,13 @@ export const useRatings = () => {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['ratings'] });
       toast({
-        title: "דירוג נשלח בהצלחה",
-        description: "תודה על המשוב שלך!",
+        title: "Rating submitted successfully",
+        description: "Thank you for your feedback!",
       });
     },
     onError: (error) => {
       toast({
-        title: "שגיאה בשליחת דירוג",
+        title: "Error submitting rating",
         description: error.message,
         variant: "destructive",
       });

--- a/src/lib/whatsappService.ts
+++ b/src/lib/whatsappService.ts
@@ -27,8 +27,8 @@ function validateWhatsAppConfig() {
   
   if (!phoneId || !token) {
     toast({
-      title: 'WhatsApp לא מוגדר',
-      description: 'אנא הגדר את פרטי WhatsApp בעמוד ההגדרות',
+      title: 'WhatsApp not configured',
+      description: 'Please configure WhatsApp details on the settings page',
       variant: 'destructive'
     });
     return false;
@@ -128,8 +128,8 @@ export async function sendWhatsAppCustomTemplate(
   
   if (!template) {
     toast({
-      title: 'שגיאה בתבנית',
-      description: `תבנית '${String(templateKey)}' לא נמצאה`,
+      title: 'Template error',
+      description: `Template '${String(templateKey)}' not found`,
       variant: 'destructive'
     });
     return;
@@ -214,7 +214,7 @@ export function getWhatsAppStatus(): {
   enabled: boolean;
   configured: boolean;
   withinBusinessHours: boolean;
-  settings: any;
+  settings: WhatsAppSettings;
 } {
   const settings = WhatsAppConfigManager.loadSettings();
   const { phoneId, token, enabled } = getWhatsAppConfig();

--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -25,12 +25,12 @@ export default function AdminDashboard() {
     <div className="p-6 space-y-6">
       <div className="flex justify-between items-center">
         <div>
-          <h1 className="text-3xl font-bold">פאנל ניהול</h1>
-          <p className="text-muted-foreground">מבט כולל על פעילות המערכת</p>
+          <h1 className="text-3xl font-bold">Admin Panel</h1>
+          <p className="text-muted-foreground">Overview of system activity</p>
         </div>
         <Button variant="outline">
           <Settings className="h-4 w-4 mr-2" />
-          הגדרות מערכת
+          System Settings
         </Button>
       </div>
 
@@ -38,52 +38,52 @@ export default function AdminDashboard() {
       <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
         <Card>
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">לידים פעילים</CardTitle>
+            <CardTitle className="text-sm font-medium">Active Leads</CardTitle>
             <Users className="h-4 w-4 text-muted-foreground" />
           </CardHeader>
           <CardContent>
             <div className="text-2xl font-bold">{leadStats.totalLeads}</div>
             <p className="text-xs text-muted-foreground">
-              {leadStats.newLeads} חדשים השבוע
+              {leadStats.newLeads} new this week
             </p>
           </CardContent>
         </Card>
 
         <Card>
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">לקוחות</CardTitle>
+            <CardTitle className="text-sm font-medium">Clients</CardTitle>
             <UserCheck className="h-4 w-4 text-muted-foreground" />
           </CardHeader>
           <CardContent>
             <div className="text-2xl font-bold">{clientStats.totalClients}</div>
             <p className="text-xs text-muted-foreground">
-              {clientStats.newThisMonth} חדשים החודש
+              {clientStats.newThisMonth} new this month
             </p>
           </CardContent>
         </Card>
 
         <Card>
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">תיקים פתוחים</CardTitle>
+            <CardTitle className="text-sm font-medium">Open Cases</CardTitle>
             <FileText className="h-4 w-4 text-muted-foreground" />
           </CardHeader>
           <CardContent>
             <div className="text-2xl font-bold">{caseStats.openCases}</div>
             <p className="text-xs text-muted-foreground">
-              מתוך {caseStats.totalCases} סך הכל
+              out of {caseStats.totalCases} total
             </p>
           </CardContent>
         </Card>
 
         <Card>
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">הכנסות חודשיות</CardTitle>
+            <CardTitle className="text-sm font-medium">Monthly Revenue</CardTitle>
             <DollarSign className="h-4 w-4 text-muted-foreground" />
           </CardHeader>
           <CardContent>
             <div className="text-2xl font-bold">₪{depositStats.totalAmount.toLocaleString()}</div>
             <p className="text-xs text-muted-foreground">
-              {depositStats.paidDeposits} פיקדונות שולמו
+              {depositStats.paidDeposits} deposits paid
             </p>
           </CardContent>
         </Card>
@@ -93,67 +93,67 @@ export default function AdminDashboard() {
       <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
         <Card>
           <CardHeader>
-            <CardTitle className="text-lg">פעולות מהירות</CardTitle>
-            <CardDescription>ניהול יומיומי של המערכת</CardDescription>
+            <CardTitle className="text-lg">Quick Actions</CardTitle>
+            <CardDescription>Daily system management</CardDescription>
           </CardHeader>
           <CardContent className="space-y-2">
             <Button className="w-full justify-start" variant="outline">
               <Users className="h-4 w-4 mr-2" />
-              ניהול עורכי דין
+              Manage Lawyers
             </Button>
             <Button className="w-full justify-start" variant="outline">
               <Settings className="h-4 w-4 mr-2" />
-              הגדרות עמלות
+              Commission Settings
             </Button>
             <Button className="w-full justify-start" variant="outline">
               <FileText className="h-4 w-4 mr-2" />
-              דוחות מתקדמים
+              Advanced Reports
             </Button>
           </CardContent>
         </Card>
 
         <Card>
           <CardHeader>
-            <CardTitle className="text-lg">התראות מערכת</CardTitle>
-            <CardDescription>נושאים הדורשים תשומת לב</CardDescription>
+            <CardTitle className="text-lg">System Alerts</CardTitle>
+            <CardDescription>Items requiring attention</CardDescription>
           </CardHeader>
           <CardContent className="space-y-3">
             <div className="flex items-center space-x-2">
               <AlertTriangle className="h-4 w-4 text-warning" />
-              <span className="text-sm">{leadStats.highPriorityLeads} לידים בדחיפות גבוהה</span>
+              <span className="text-sm">{leadStats.highPriorityLeads} high priority leads</span>
             </div>
             <div className="flex items-center space-x-2">
               <Calendar className="h-4 w-4 text-primary" />
-              <span className="text-sm">{meetingStats.today} פגישות היום</span>
+              <span className="text-sm">{meetingStats.today} meetings today</span>
             </div>
             <div className="flex items-center space-x-2">
               <DollarSign className="h-4 w-4 text-success" />
-              <span className="text-sm">{depositStats.pendingDeposits} פיקדונות בהמתנה</span>
+              <span className="text-sm">{depositStats.pendingDeposits} pending deposits</span>
             </div>
           </CardContent>
         </Card>
 
         <Card>
           <CardHeader>
-            <CardTitle className="text-lg">ביצועים השבוע</CardTitle>
-            <CardDescription>סטטיסטיקות עדכניות</CardDescription>
+            <CardTitle className="text-lg">This Week's Performance</CardTitle>
+            <CardDescription>Updated statistics</CardDescription>
           </CardHeader>
           <CardContent className="space-y-3">
             <div className="flex justify-between items-center">
-              <span className="text-sm">שיעור המרה</span>
+              <span className="text-sm">Conversion Rate</span>
               <Badge variant="secondary">
-                {leadStats.totalLeads > 0 
+                {leadStats.totalLeads > 0
                   ? `${Math.round((leadStats.convertedLeads / leadStats.totalLeads) * 100)}%`
                   : '0%'
                 }
               </Badge>
             </div>
             <div className="flex justify-between items-center">
-              <span className="text-sm">פגישות שהושלמו</span>
+              <span className="text-sm">Meetings Completed</span>
               <Badge variant="secondary">{meetingStats.completed}</Badge>
             </div>
             <div className="flex justify-between items-center">
-              <span className="text-sm">לקוחות פעילים</span>
+              <span className="text-sm">Active Clients</span>
               <Badge variant="secondary">{clientStats.activeClients}</Badge>
             </div>
           </CardContent>
@@ -163,25 +163,25 @@ export default function AdminDashboard() {
       {/* Recent Activity */}
       <Card>
         <CardHeader>
-          <CardTitle>פעילות אחרונה</CardTitle>
-          <CardDescription>עדכונים אחרונים במערכת</CardDescription>
+          <CardTitle>Recent Activity</CardTitle>
+          <CardDescription>Latest updates in the system</CardDescription>
         </CardHeader>
         <CardContent>
           <div className="space-y-4">
             <div className="flex items-center space-x-3">
               <div className="w-2 h-2 bg-primary rounded-full"></div>
-              <span className="text-sm">ליד חדש נוצר: לקוח פוטנציאלי בתחום דיני משפחה</span>
-              <span className="text-xs text-muted-foreground">לפני 5 דקות</span>
+              <span className="text-sm">New lead created: potential client in family law</span>
+              <span className="text-xs text-muted-foreground">5 minutes ago</span>
             </div>
             <div className="flex items-center space-x-3">
               <div className="w-2 h-2 bg-success rounded-full"></div>
-              <span className="text-sm">פגישה הושלמה: ליד הומר ללקוח משלם</span>
-              <span className="text-xs text-muted-foreground">לפני 23 דקות</span>
+              <span className="text-sm">Meeting completed: lead converted to paying client</span>
+              <span className="text-xs text-muted-foreground">23 minutes ago</span>
             </div>
             <div className="flex items-center space-x-3">
               <div className="w-2 h-2 bg-warning rounded-full"></div>
-              <span className="text-sm">פיקדון התקבל: ₪5,000 עבור תיק משפט מסחרי</span>
-              <span className="text-xs text-muted-foreground">לפני שעה</span>
+              <span className="text-sm">Deposit received: ₪5,000 for commercial law case</span>
+              <span className="text-xs text-muted-foreground">1 hour ago</span>
             </div>
           </div>
         </CardContent>

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -76,9 +76,9 @@ export default function Dashboard() {
     setIsLoadingSummary(true);
     try {
       await refetchSummary();
-      toast.success("סיכום עודכן בהצלחה");
+      toast.success("Summary updated successfully");
     } catch (error) {
-      toast.error("שגיאה בעדכון הסיכום");
+      toast.error("Error updating summary");
     } finally {
       setIsLoadingSummary(false);
     }
@@ -95,30 +95,30 @@ export default function Dashboard() {
 
   const stats = [
     {
-      title: "סה״כ לידים",
+      title: "Total Leads",
       value: leadStats.totalLeads,
-      change: `${leadStats.newLeads} חדשים`,
+      change: `${leadStats.newLeads} new`,
       icon: UserPlus,
       trend: "up" as const
     },
     {
-      title: "לידים גבוהי עדיפות",
+      title: "High Priority Leads",
       value: leadStats.highPriorityLeads,
-      change: `${leadStats.convertedLeads} הומרו`,
+      change: `${leadStats.convertedLeads} converted`,
       icon: TrendingUp,
       trend: "up" as const
     },
     {
-      title: "סה״כ תשלומים",
+      title: "Total Payments",
       value: `₪${totalPayments.toLocaleString()}`,
-      change: `${payments?.length || 0} תשלומים`,
+      change: `${payments?.length || 0} payments`,
       icon: DollarSign,
       trend: "up" as const
     },
     {
-      title: "פגישות היום",
+      title: "Meetings Today",
       value: todayMeetings.length,
-      change: `${meetings?.length || 0} סה״כ פגישות`,
+      change: `${meetings?.length || 0} total meetings`,
       icon: Calendar,
       trend: "neutral" as const
     }
@@ -138,10 +138,10 @@ export default function Dashboard() {
     const hasMeeting = lead.meetings && lead.meetings.length > 0;
     const hasDeposit = lead.deposits && lead.deposits.length > 0;
     
-    if (hasDeposit) return { status: "מונטז", icon: CheckCircle, color: "text-green-600" };
-    if (hasMeeting) return { status: "פגישה נקבעה", icon: Calendar, color: "text-blue-600" };
-    if (hasQuote) return { status: "הצעת מחיר נשלחה", icon: FileText, color: "text-orange-600" };
-    return { status: "בהמתנה", icon: Clock, color: "text-gray-600" };
+    if (hasDeposit) return { status: "Monetized", icon: CheckCircle, color: "text-green-600" };
+    if (hasMeeting) return { status: "Meeting Scheduled", icon: Calendar, color: "text-blue-600" };
+    if (hasQuote) return { status: "Quote Sent", icon: FileText, color: "text-orange-600" };
+    return { status: "Pending", icon: Clock, color: "text-gray-600" };
   };
 
   const getPriorityVariant = (priority: string) => {
@@ -164,13 +164,13 @@ export default function Dashboard() {
   }
 
   return (
-    <div className="w-full max-w-7xl mx-auto p-3 sm:p-4 md:p-6 space-y-4 md:space-y-6 animate-fade-in flex flex-col overflow-x-hidden" dir="rtl">
+    <div className="w-full max-w-7xl mx-auto p-3 sm:p-4 md:p-6 space-y-4 md:space-y-6 animate-fade-in flex flex-col overflow-x-hidden">
       {/* Header */}
       <div className="flex flex-col sm:flex-row gap-4 sm:justify-between sm:items-center animate-slide-in-right">
         <div className="space-y-1">
-          <h1 className="text-2xl sm:text-3xl font-bold text-primary animate-fade-in">דשבורד ראשי</h1>
+          <h1 className="text-2xl sm:text-3xl font-bold text-primary animate-fade-in">Main Dashboard</h1>
           <p className="text-sm sm:text-base text-muted-foreground animate-fade-in" style={{ animationDelay: '100ms' }}>
-            סקירה כללית של פעילות המשרד - עדכון אוטומטי
+            Overview of firm activity - automatic updates
           </p>
         </div>
         <div className="flex gap-2 flex-col sm:flex-row">
@@ -179,14 +179,14 @@ export default function Dashboard() {
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="today">היום</SelectItem>
-              <SelectItem value="week">השבוע</SelectItem>
-              <SelectItem value="month">החודש</SelectItem>
+              <SelectItem value="today">Today</SelectItem>
+              <SelectItem value="week">This Week</SelectItem>
+              <SelectItem value="month">This Month</SelectItem>
             </SelectContent>
           </Select>
           <Button className="gap-2 w-full sm:w-auto hover-scale animate-scale-in" style={{ animationDelay: '200ms' }}>
             <Plus className="h-4 w-4" />
-            ליד חדש
+            New Lead
           </Button>
         </div>
       </div>
@@ -210,7 +210,7 @@ export default function Dashboard() {
           <div className="flex flex-col sm:flex-row gap-3 sm:items-center sm:justify-between">
             <CardTitle className="flex items-center gap-2 text-lg">
               <Brain className="h-5 w-5 animate-pulse" />
-              סיכום AI של המשרד
+              Firm AI Summary
             </CardTitle>
             <Button 
               variant="outline" 
@@ -220,11 +220,11 @@ export default function Dashboard() {
               className="gap-2 w-full sm:w-auto hover-scale"
             >
               <RefreshCw className={`h-4 w-4 ${isLoadingSummary ? 'animate-spin' : ''}`} />
-              רענן
+              Refresh
             </Button>
           </div>
           <CardDescription className="text-sm">
-            ניתוח אוטומטי של נתוני המשרד עם תובנות והמלצות
+            Automatic analysis of firm data with insights and recommendations
           </CardDescription>
         </CardHeader>
         <CardContent className="pt-0">
@@ -235,7 +235,7 @@ export default function Dashboard() {
               </div>
               {aiSummary.timestamp && (
                 <p className="text-xs text-muted-foreground">
-                  עודכן לאחרונה: {new Date(aiSummary.timestamp).toLocaleString('he-IL')}
+                  Last updated: {new Date(aiSummary.timestamp).toLocaleString('en-US')}
                 </p>
               )}
             </div>
@@ -243,7 +243,7 @@ export default function Dashboard() {
             <div className="flex items-center justify-center p-6 sm:p-8 text-muted-foreground">
               <div className="text-center space-y-2 animate-fade-in">
                 <Brain className="h-8 w-8 mx-auto opacity-50 animate-pulse" />
-                <p className="text-sm">לחץ על "רענן" לקבלת סיכום AI</p>
+                <p className="text-sm">Click "Refresh" to get AI summary</p>
               </div>
             </div>
           )}
@@ -257,10 +257,10 @@ export default function Dashboard() {
           <CardHeader className="pb-3">
             <CardTitle className="flex items-center gap-2 text-lg">
               <UserPlus className="h-5 w-5" />
-              לידים אחרונים
+              Recent Leads
             </CardTitle>
             <CardDescription className="text-sm">
-              לידים שהתקבלו לאחרונה עם סטטוס פייפליין
+              Recently received leads with pipeline status
             </CardDescription>
           </CardHeader>
           <CardContent className="pt-0">
@@ -300,10 +300,10 @@ export default function Dashboard() {
           <CardHeader className="pb-3">
             <CardTitle className="flex items-center gap-2 text-lg">
               <Activity className="h-5 w-5" />
-              פעילות פייפליין אוטומטי
+              Automated Pipeline Activity
             </CardTitle>
             <CardDescription className="text-sm">
-              מעקב אחר תהליכים אוטומטיים
+              Tracking automated processes
             </CardDescription>
           </CardHeader>
           <CardContent className="pt-0">
@@ -324,7 +324,7 @@ export default function Dashboard() {
                     <div className="flex-1 space-y-1">
                       <div className="font-medium text-sm sm:text-base">{lead.customer_name}</div>
                       <div className="text-xs sm:text-sm text-muted-foreground">
-                        {lead.legal_category} • {new Date(lead.created_at).toLocaleDateString('he-IL')}
+                        {lead.legal_category} • {new Date(lead.created_at).toLocaleDateString('en-US')}
                       </div>
                     </div>
                   </div>
@@ -342,10 +342,10 @@ export default function Dashboard() {
           <CardHeader className="pb-3">
             <CardTitle className="flex items-center gap-2 text-lg">
               <Calendar className="h-5 w-5" />
-              פגישות היום
+              Today's Meetings
             </CardTitle>
             <CardDescription className="text-sm">
-              פגישות שנקבעו להיום
+              Meetings scheduled for today
             </CardDescription>
           </CardHeader>
           <CardContent className="pt-0">
@@ -358,13 +358,13 @@ export default function Dashboard() {
                   >
                     <div className="flex items-center gap-2 text-primary font-medium text-sm">
                       <Clock className="h-4 w-4" />
-                      {new Date(meeting.scheduled_at).toLocaleTimeString('he-IL', { 
-                        hour: '2-digit', 
-                        minute: '2-digit' 
+                      {new Date(meeting.scheduled_at).toLocaleTimeString('en-US', {
+                        hour: '2-digit',
+                        minute: '2-digit'
                       })}
                     </div>
                     <div className="flex-1 space-y-1">
-                      <div className="font-medium text-sm sm:text-base">פגישה עם לקוח</div>
+                      <div className="font-medium text-sm sm:text-base">Meeting with client</div>
                       <div className="text-xs sm:text-sm text-muted-foreground">{meeting.meeting_type}</div>
                     </div>
                   </div>
@@ -372,7 +372,7 @@ export default function Dashboard() {
               ) : (
                 <div className="text-center py-8 text-muted-foreground">
                   <Calendar className="h-8 w-8 mx-auto mb-2 opacity-50" />
-                  <p className="text-sm">אין פגישות מתוכננות להיום</p>
+                  <p className="text-sm">No meetings scheduled for today</p>
                 </div>
               )}
             </div>

--- a/src/pages/Landing.tsx
+++ b/src/pages/Landing.tsx
@@ -5,7 +5,7 @@ import { Link } from "react-router-dom";
 
 const Landing = () => {
   return (
-    <div className="min-h-screen bg-gradient-to-br from-primary/5 to-accent/5 flex flex-col overflow-x-hidden" dir="rtl">
+    <div className="min-h-screen bg-gradient-to-br from-primary/5 to-accent/5 flex flex-col overflow-x-hidden">
       {/* Header */}
       <header className="container mx-auto px-4 py-6">
         <div className="flex justify-between items-center">
@@ -15,10 +15,10 @@ const Landing = () => {
           </div>
           <div className="flex gap-4">
             <Button variant="ghost" asChild>
-              <Link to="/auth">התחברות</Link>
+              <Link to="/auth">Login</Link>
             </Button>
             <Button asChild>
-              <Link to="/auth">הרשמה</Link>
+              <Link to="/auth">Register</Link>
             </Button>
           </div>
         </div>
@@ -27,13 +27,13 @@ const Landing = () => {
       {/* Hero Section */}
       <section className="container mx-auto px-4 py-20 text-center">
         <h2 className="text-4xl md:text-6xl font-bold mb-6 text-foreground">
-          מערכת ניהול משרד עורכי דין מתקדמת
+          Advanced Law Firm Management System
         </h2>
         <p className="text-xl text-muted-foreground mb-8 max-w-3xl mx-auto">
-          נהל לקוחות, תיקים, תשלומים ועמלות במקום אחד. מערכת שנבנתה במיוחד למשרדי עורכי דין בישראל
+          Manage clients, cases, payments, and commissions in one place. Built specifically for law firms in Israel.
         </p>
         <Button size="lg" asChild>
-          <Link to="/auth">התחל עכשיו בחינם</Link>
+          <Link to="/auth">Start for Free</Link>
         </Button>
       </section>
 
@@ -43,9 +43,9 @@ const Landing = () => {
           <Card>
             <CardHeader>
               <Users className="h-10 w-10 text-primary mb-2" />
-              <CardTitle>ניהול לקוחות</CardTitle>
+              <CardTitle>Client Management</CardTitle>
               <CardDescription>
-                מעקב אחר פרטי לקוחות, היסטוריית קשר וסטטוס תיקים
+                Track client details, contact history and case status
               </CardDescription>
             </CardHeader>
           </Card>
@@ -53,9 +53,9 @@ const Landing = () => {
           <Card>
             <CardHeader>
               <Scale className="h-10 w-10 text-primary mb-2" />
-              <CardTitle>ניהול תיקים</CardTitle>
+              <CardTitle>Case Management</CardTitle>
               <CardDescription>
-                ארגון תיקים משפטיים, מעקב סטטוס ותזמון דיונים
+                Organize legal cases, track status and schedule hearings
               </CardDescription>
             </CardHeader>
           </Card>
@@ -63,9 +63,9 @@ const Landing = () => {
           <Card>
             <CardHeader>
               <Shield className="h-10 w-10 text-primary mb-2" />
-              <CardTitle>ניהול תשלומים</CardTitle>
+              <CardTitle>Payment Management</CardTitle>
               <CardDescription>
-                מעקב אחר חשבוניות, תשלומים ויתרות חובה
+                Track invoices, payments and balances
               </CardDescription>
             </CardHeader>
           </Card>
@@ -73,9 +73,9 @@ const Landing = () => {
           <Card>
             <CardHeader>
               <ChartBar className="h-10 w-10 text-primary mb-2" />
-              <CardTitle>דוחות ואנליטיקס</CardTitle>
+              <CardTitle>Reports & Analytics</CardTitle>
               <CardDescription>
-                דוחות מפורטים על ביצועים ורווחיות המשרד
+                Detailed reports on performance and profitability
               </CardDescription>
             </CardHeader>
           </Card>

--- a/src/pages/LeadsPortal.tsx
+++ b/src/pages/LeadsPortal.tsx
@@ -207,7 +207,7 @@ export default function LeadsPortal() {
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-primary/5 via-background to-secondary/5 flex flex-col overflow-x-hidden" dir="rtl">
+    <div className="min-h-screen bg-gradient-to-br from-primary/5 via-background to-secondary/5 flex flex-col overflow-x-hidden">
       {/* Header */}
       <div className="bg-white/80 backdrop-blur-sm border-b sticky top-0 z-40">
         <div className="max-w-7xl mx-auto px-4 py-4">
@@ -392,7 +392,7 @@ export default function LeadsPortal() {
 
       {/* Lead Details Dialog */}
       <Dialog open={!!selectedLead} onOpenChange={() => setSelectedLead(null)}>
-        <DialogContent className="max-w-2xl max-h-[80vh] overflow-y-auto" dir="rtl">
+        <DialogContent className="max-w-2xl max-h-[80vh] overflow-y-auto">
           {selectedLead && (
             <>
               <DialogHeader>
@@ -468,7 +468,7 @@ export default function LeadsPortal() {
 
       {/* Registration Dialog */}
       <Dialog open={showRegistration} onOpenChange={setShowRegistration}>
-        <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto" dir="rtl">
+        <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
           <DialogHeader>
             <DialogTitle className="flex items-center gap-2">
               <Users className="h-5 w-5" />


### PR DESCRIPTION
## Summary
- Replace Hebrew labels with English across core UI and hooks
- Remove RTL direction attributes to switch interface to left-to-right
- Update WhatsApp service, lead and rating hooks for English messages

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any in several files)*

------
https://chatgpt.com/codex/tasks/task_e_6899d09383608323ae781d944b274306