### PR TITLE
Add consent tracking and account management

### DIFF
--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -11,6 +11,7 @@ import { toast } from "@/components/ui/use-toast"
 import { useState, useEffect } from "react"
 import { useRole } from "@/hooks/useRole"
 import { WhatsAppConfigManager, ROLE_WHATSAPP_FEATURES, type WhatsAppSettings } from "@/lib/whatsappConfig"
+import { supabase } from "@/integrations/supabase/client"
 
 const Settings = () => {
   const { role } = useRole();
@@ -131,6 +132,49 @@ const Settings = () => {
     } finally {
       setIsTesting(false);
     }
+  };
+
+  const exportCase = async () => {
+    try {
+      const {
+        data: { user }
+      } = await supabase.auth.getUser();
+      if (!user) {
+        return;
+      }
+      const res = await fetch(`/functions/v1/case-export?caseId=${user.id}`);
+      if (!res.ok) {
+        throw new Error("export failed");
+      }
+      const blob = await res.blob();
+      const url = window.URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `case-${user.id}.zip`;
+      a.click();
+      window.URL.revokeObjectURL(url);
+    } catch (e) {
+      toast({ title: "שגיאה בייצוא", variant: "destructive" });
+    }
+  };
+
+  const deleteAccount = async () => {
+    const {
+      data: { user }
+    } = await supabase.auth.getUser();
+    if (!user) {
+      return;
+    }
+    const { error } = await supabase
+      .from("profiles")
+      .update({ delete_requested: true })
+      .eq("user_id", user.id);
+    if (error) {
+      toast({ title: "שגיאה במחיקה", variant: "destructive" });
+      return;
+    }
+    toast({ title: "החשבון יסומן למחיקה" });
+    await supabase.auth.signOut();
   };
 
   return (
@@ -616,10 +660,10 @@ const Settings = () => {
                 <Database className="h-4 w-4 mr-2" />
                 גבה נתונים
               </Button>
-              <Button variant="outline">
-                ייצא לאקסל
+              <Button variant="outline" onClick={exportCase}>
+                ייצוא תיק
               </Button>
-              <Button variant="destructive">
+              <Button variant="destructive" onClick={deleteAccount}>
                 מחק חשבון
               </Button>
             </div>

--- a/supabase/functions/anonymize-deleted-users/index.ts
+++ b/supabase/functions/anonymize-deleted-users/index.ts
@@ -1,0 +1,26 @@
+import { serve } from "https://deno.land/std@0.177.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+serve(async () => {
+  const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
+  const serviceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+  const client = createClient(supabaseUrl, serviceKey);
+
+  const { data: profiles } = await client
+    .from("profiles")
+    .select("id, user_id")
+    .eq("delete_requested", true)
+    .eq("anonymized", false);
+
+  for (const profile of profiles ?? []) {
+    await client.from("profiles").update({
+      company_name: null,
+      avatar_url: null,
+      consent: false,
+      anonymized: true
+    }).eq("id", profile.id);
+    await client.auth.admin.deleteUser(profile.user_id);
+  }
+
+  return new Response("ok");
+});

--- a/supabase/functions/case-export/index.ts
+++ b/supabase/functions/case-export/index.ts
@@ -1,0 +1,43 @@
+import { serve } from "https://deno.land/std@0.177.0/http/server.ts";
+import JSZip from "npm:jszip@3.10.1";
+import { PDFDocument } from "npm:pdf-lib@1.17.1";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+serve(async (req) => {
+  const url = new URL(req.url);
+  const caseId = url.searchParams.get("caseId");
+  if (!caseId) {
+    return new Response("caseId required", { status: 400 });
+  }
+
+  const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
+  const supabaseKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+  const supabase = createClient(supabaseUrl, supabaseKey);
+
+  const { data, error } = await supabase
+    .from("cases")
+    .select("id, title, client_id, legal_category, status, priority, estimated_budget, assigned_lawyer_id, notes, opened_at")
+    .eq("id", caseId)
+    .single();
+
+  if (error || !data) {
+    return new Response("case not found", { status: 404 });
+  }
+
+  const pdf = await PDFDocument.create();
+  const page = pdf.addPage();
+  const content = JSON.stringify(data, null, 2);
+  page.drawText(content, { x: 40, y: page.getHeight() - 40, size: 12 });
+  const pdfBytes = await pdf.save();
+
+  const zip = new JSZip();
+  zip.file(`case-${caseId}.pdf`, pdfBytes);
+  const zipBytes = await zip.generateAsync({ type: "uint8array" });
+
+  return new Response(zipBytes, {
+    headers: {
+      "Content-Type": "application/zip",
+      "Content-Disposition": `attachment; filename=case-${caseId}.zip`
+    }
+  });
+});

--- a/supabase/migrations/20250812090000_create_consent_and_deletion_hooks.sql
+++ b/supabase/migrations/20250812090000_create_consent_and_deletion_hooks.sql
@@ -1,0 +1,29 @@
+-- Create consent events table
+create table if not exists public.consent_events (
+  id uuid primary key default gen_random_uuid(),
+  profile_id uuid references public.profiles(id) on delete cascade,
+  consent boolean not null,
+  recorded_at timestamptz not null default now()
+);
+
+-- Add consent and deletion flags to profiles
+alter table public.profiles
+  add column if not exists consent boolean default false,
+  add column if not exists delete_requested boolean default false,
+  add column if not exists anonymized boolean default false;
+
+-- Trigger to log consent changes
+create or replace function public.log_consent_change()
+returns trigger as $$
+begin
+  insert into public.consent_events(profile_id, consent)
+  values (new.id, new.consent);
+  return new;
+end;
+$$ language plpgsql security definer;
+
+create trigger on_consent_change
+after update of consent on public.profiles
+for each row
+when (new.consent is distinct from old.consent)
+execute function public.log_consent_change();


### PR DESCRIPTION
## Summary
- track user consent changes with new table and trigger
- enable account export and deletion options in settings
- provide edge functions for case export and scheduled anonymization

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any, ban-ts-comment)*

------
https://chatgpt.com/codex/tasks/task_e_689a624baf3883239fc86215f8bb724f