### PR TITLE
Add evidence upload service

### DIFF
--- a/src/components/EvidenceUploader.tsx
+++ b/src/components/EvidenceUploader.tsx
@@ -1,0 +1,29 @@
+import { useState } from 'react';
+import { uploadToSignedUrl } from '@/services/evidence';
+
+interface EvidenceUploaderProps {
+  signedUrl: string;
+}
+
+export function EvidenceUploader({ signedUrl }: EvidenceUploaderProps) {
+  const [error, setError] = useState('');
+
+  const handleChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    try {
+      await uploadToSignedUrl(signedUrl, file);
+    } catch (err) {
+      setError((err as Error).message);
+    }
+  };
+
+  return (
+    <div>
+      <input type="file" onChange={handleChange} />
+      {error && <p>{error}</p>}
+    </div>
+  );
+}
+
+export default EvidenceUploader;

--- a/src/services/evidence.ts
+++ b/src/services/evidence.ts
@@ -1,0 +1,11 @@
+export function uploadToSignedUrl(url: string, file: File) {
+  return fetch(url, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': file.type
+    },
+    body: file
+  });
+}
+
+export default uploadToSignedUrl;


### PR DESCRIPTION
Summary
- add uploadToSignedUrl helper
- integrate EvidenceUploader with service

Testing
- npm test
- npm run lint (fails: existing lint errors)


------
https://chatgpt.com/codex/tasks/task_e_689a6217e4588323bdf4fb3de302e41d