### PR TITLE
docs: add sync runbook and security headers

### DIFF
--- a/BUILD_AND_DEPLOY.md
+++ b/BUILD_AND_DEPLOY.md
@@ -110,6 +110,19 @@ After deployment, test these key features:
 2. **API Errors**: Check Supabase Secrets configuration
 3. **Performance**: Monitor Edge Function logs
 
+## Repository Sync
+
+Manual steps to update the `upstream-main` folder from the external mirror:
+
+1. Trigger the **sync-from-external** workflow in GitHub Actions.
+2. Verify a pull request titled `Sync external: The-new-ben/lawyer-opportunity-hub → upstream-main` is created.
+3. Review the PR and merge or cherry-pick changes as required.
+
+### Sync Troubleshooting
+
+- **No Pull Request created:** Ensure the `MIRROR_TOKEN` secret is configured in repository settings.
+- **Conflicts while merging:** Re-run the workflow after resolving conflicts locally.
+
 ## Security Checklist
 
 - ✅ No API keys in source code

--- a/LOGGING.md
+++ b/LOGGING.md
@@ -1,0 +1,10 @@
+# Logging Guidelines
+
+Use structured JSON logs with the keys `level`, `message`, and `context`.
+
+```ts
+console.info(JSON.stringify({ level: 'info', message: 'service started', context: { requestId } }))
+console.error(JSON.stringify({ level: 'error', message: err.message, context: { requestId } }))
+```
+
+Include a `requestId` whenever available to aid traceability.

--- a/netlify.toml
+++ b/netlify.toml
@@ -9,3 +9,5 @@
     X-Frame-Options = "SAMEORIGIN"
     X-Content-Type-Options = "nosniff"
     Referrer-Policy = "strict-origin-when-cross-origin"
+    Strict-Transport-Security = "max-age=63072000; includeSubDomains; preload"
+    Content-Security-Policy = "default-src 'self'; img-src 'self' data: https:; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://*.supabase.co"


### PR DESCRIPTION
## Summary
- document workflow for syncing external repository
- add security headers for Netlify build
- establish basic logging conventions

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any and ban-ts-comment errors)*

------
https://chatgpt.com/codex/tasks/task_e_689a4b8f72e48323b62c912ebc1e2981