### PR TITLE
feat: add deposit service

### DIFF
--- a/src/components/CreateDepositDialog.tsx
+++ b/src/components/CreateDepositDialog.tsx
@@ -6,6 +6,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
 import { Plus, CreditCard } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
+import { createDeposit } from '@/services/payments';
 
 export function CreateDepositDialog() {
   const [isOpen, setIsOpen] = useState(false);
@@ -32,18 +33,13 @@ export function CreateDepositDialog() {
     }
 
     try {
-      const res = await fetch('/api/payments/checkout', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          lead_id: depositData.lead_id,
-          lawyer_id: depositData.lawyer_id,
-          amount: parseFloat(depositData.amount),
-          deposit_type: depositData.deposit_type,
-          payment_method: depositData.payment_method,
-        }),
+      const data = await createDeposit({
+        lead_id: depositData.lead_id,
+        lawyer_id: depositData.lawyer_id,
+        amount: parseFloat(depositData.amount),
+        deposit_type: depositData.deposit_type,
+        payment_method: depositData.payment_method,
       });
-      const data = await res.json();
       if (data.url) {
         window.location.href = data.url;
       }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,13 +1,22 @@
 import { supabase } from "@/integrations/supabase/client";
 
+export const api = async (path: string, options: RequestInit = {}) => {
+  const res = await fetch(path, {
+    ...options,
+    headers: { "Content-Type": "application/json", ...(options.headers || {}) },
+  });
+  if (!res.ok) throw new Error("API error");
+  return res.json();
+};
+
 export const addCourtReminder = async (payload: { caseId: string; remindAt: string; notes?: string }) => {
-  const { data, error } = await supabase.functions.invoke('court-reminder', { body: payload });
+  const { data, error } = await supabase.functions.invoke("court-reminder", { body: payload });
   if (error) throw error;
   return data;
 };
 
 export const uploadCourtDocument = async (payload: { caseId: string; documentUrl: string; description?: string }) => {
-  const { data, error } = await supabase.functions.invoke('court-document-upload', { body: payload });
+  const { data, error } = await supabase.functions.invoke("court-document-upload", { body: payload });
   if (error) throw error;
   return data;
 };

--- a/src/services/payments.ts
+++ b/src/services/payments.ts
@@ -1,0 +1,16 @@
+import { api } from "@/lib/api";
+
+type DepositPayload = {
+  lead_id: string;
+  lawyer_id: string;
+  amount: number;
+  deposit_type: string;
+  payment_method: string;
+};
+
+export const createDeposit = (payload: DepositPayload) => {
+  return api("/api/payments/checkout", {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+};


### PR DESCRIPTION
## Summary
- add generic api helper and deposit service
- use deposit service in CreateDepositDialog

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_689a621527848323b6a858b8be4a2114