### PR TITLE
feat: sanitize text highlighting

### DIFF
--- a/src/utils/textHighlight.ts
+++ b/src/utils/textHighlight.ts
@@ -1,0 +1,19 @@
+export function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;")
+}
+
+function escapeRegExp(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+}
+
+export function highlightText(text: string, query: string): string {
+  const escapedText = escapeHtml(text)
+  if (!query) return escapedText
+  const pattern = new RegExp(`(${escapeRegExp(query)})`, "gi")
+  return escapedText.replace(pattern, "<mark>$1</mark>")
+}


### PR DESCRIPTION
## Summary
- add escapeHtml and highlightText utilities
- ensure highlighting uses sanitized HTML output

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a621552848323a5d196878dab6bbf