### PR TITLE
Handle empty API responses gracefully

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,13 +1,44 @@
-import { supabase } from "@/integrations/supabase/client";
+export async function handleResponse(res: Response): Promise<any> {
+  if (res.status === 204) return undefined
+  const contentType = res.headers.get("content-type")
+  if (contentType && contentType.includes("application/json")) {
+    const text = await res.clone().text()
+    if (!text) return undefined
+    return res.json()
+  }
+  const text = await res.text()
+  return text || undefined
+}
 
-export const addCourtReminder = async (payload: { caseId: string; remindAt: string; notes?: string }) => {
-  const { data, error } = await supabase.functions.invoke('court-reminder', { body: payload });
-  if (error) throw error;
-  return data;
-};
+export async function apiRequest(
+  input: RequestInfo | URL,
+  init?: RequestInit
+): Promise<any> {
+  const res = await fetch(input, init)
+  if (!res.ok) throw new Error(res.statusText)
+  return handleResponse(res)
+}
 
-export const uploadCourtDocument = async (payload: { caseId: string; documentUrl: string; description?: string }) => {
-  const { data, error } = await supabase.functions.invoke('court-document-upload', { body: payload });
-  if (error) throw error;
-  return data;
-};
+export const addCourtReminder = async (payload: {
+  caseId: string
+  remindAt: string
+  notes?: string
+}) => {
+  return apiRequest("/api/court-reminder", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload)
+  })
+}
+
+export const uploadCourtDocument = async (payload: {
+  caseId: string
+  documentUrl: string
+  description?: string
+}) => {
+  return apiRequest("/api/court-document-upload", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload)
+  })
+}


### PR DESCRIPTION
## Summary
- add response handler that checks status and content-type before parsing
- return undefined or raw text for 204 or empty responses
- route court reminder and document upload through new apiRequest helper

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a621cdfa883238404b310499f8631