### PR TITLE
feat: add theme tokens and RTL support

### DIFF
--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,19 +1,28 @@
+import { useEffect, useState } from "react"
 import { Moon, Sun } from "lucide-react"
 import { Button } from "@/components/ui/button"
-import { useTheme } from "next-themes"
 
 export function ThemeToggle() {
-  const { theme, setTheme } = useTheme()
-
+  const [mode, setMode] = useState("light")
+  useEffect(() => {
+    const stored = localStorage.getItem("theme")
+    if (stored === "dark") {
+      document.documentElement.classList.add("dark")
+      setMode("dark")
+    }
+  }, [])
+  function toggle() {
+    const next = mode === "dark" ? "light" : "dark"
+    document.documentElement.classList.toggle("dark", next === "dark")
+    localStorage.setItem("theme", next)
+    setMode(next)
+  }
   return (
-    <Button
-      variant="ghost"
-      size="icon"
-      onClick={() => setTheme(theme === "light" ? "dark" : "light")}
-    >
-      <Sun className="h-5 w-5 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
-      <Moon className="absolute h-5 w-5 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
+    <Button variant="ghost" size="icon" onClick={toggle}>
+      <Sun className={mode === "dark" ? "h-5 w-5 -rotate-90 scale-0 transition-all" : "h-5 w-5 rotate-0 scale-100 transition-all"} />
+      <Moon className={mode === "dark" ? "absolute h-5 w-5 rotate-0 scale-100 transition-all" : "absolute h-5 w-5 rotate-90 scale-0 transition-all"} />
       <span className="sr-only">Toggle theme</span>
     </Button>
   )
 }
+

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,20 +1,36 @@
 import * as React from "react"
-
+import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
-const Card = React.forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement>
->(({ className, ...props }, ref) => (
-  <div
-    ref={ref}
-    className={cn(
-      "rounded-lg border bg-card text-card-foreground shadow-sm",
-      className
-    )}
-    {...props}
-  />
-))
+const cardVariants = cva(
+  "rounded-lg border bg-card text-card-foreground shadow-sm",
+  {
+    variants: {
+      variant: {
+        default: "",
+        elevated: "shadow-md",
+        ghost: "border-none shadow-none",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+export interface CardProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof cardVariants> {}
+
+const Card = React.forwardRef<HTMLDivElement, CardProps>(
+  ({ className, variant, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn(cardVariants({ variant, className }))}
+      {...props}
+    />
+  )
+)
 Card.displayName = "Card"
 
 const CardHeader = React.forwardRef<
@@ -76,4 +92,12 @@ const CardFooter = React.forwardRef<
 ))
 CardFooter.displayName = "CardFooter"
 
-export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent }
+export {
+  Card,
+  cardVariants,
+  CardHeader,
+  CardFooter,
+  CardTitle,
+  CardDescription,
+  CardContent,
+}

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -1,35 +1,68 @@
 import * as React from "react"
 import * as TabsPrimitive from "@radix-ui/react-tabs"
-
+import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const Tabs = TabsPrimitive.Root
 
+const tabsListVariants = cva(
+  "inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground",
+  {
+    variants: {
+      variant: {
+        default: "",
+        outline: "border bg-transparent",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
 const TabsList = React.forwardRef<
   React.ElementRef<typeof TabsPrimitive.List>,
-  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
->(({ className, ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List> &
+    VariantProps<typeof tabsListVariants>
+>(({ className, variant, ...props }, ref) => (
   <TabsPrimitive.List
     ref={ref}
-    className={cn(
-      "inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground",
-      className
-    )}
+    className={cn(tabsListVariants({ variant, className }))}
     {...props}
   />
 ))
 TabsList.displayName = TabsPrimitive.List.displayName
 
+const tabsTriggerVariants = cva(
+  "inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm",
+  {
+    variants: {
+      variant: {
+        default: "",
+        outline:
+          "border-b-2 border-transparent data-[state=active]:border-primary",
+      },
+      size: {
+        default: "",
+        sm: "px-2 py-1 text-xs",
+        lg: "px-5 py-3 text-base",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+
 const TabsTrigger = React.forwardRef<
   React.ElementRef<typeof TabsPrimitive.Trigger>,
-  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
->(({ className, ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger> &
+    VariantProps<typeof tabsTriggerVariants>
+>(({ className, variant, size, ...props }, ref) => (
   <TabsPrimitive.Trigger
     ref={ref}
-    className={cn(
-      "inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm",
-      className
-    )}
+    className={cn(tabsTriggerVariants({ variant, size, className }))}
     {...props}
   />
 ))
@@ -50,4 +83,12 @@ const TabsContent = React.forwardRef<
 ))
 TabsContent.displayName = TabsPrimitive.Content.displayName
 
-export { Tabs, TabsList, TabsTrigger, TabsContent }
+export {
+  Tabs,
+  TabsList,
+  TabsTrigger,
+  TabsContent,
+  tabsListVariants,
+  tabsTriggerVariants,
+}
+

--- a/src/hooks/useRTL.ts
+++ b/src/hooks/useRTL.ts
@@ -1,0 +1,15 @@
+import { useCallback, useEffect, useState } from "react"
+
+export function useRTL() {
+  const [dir, setDir] = useState<"ltr" | "rtl">("ltr")
+  useEffect(() => {
+    setDir(document.dir === "rtl" ? "rtl" : "ltr")
+  }, [])
+  const toggle = useCallback(() => {
+    const next = dir === "rtl" ? "ltr" : "rtl"
+    document.dir = next
+    setDir(next)
+  }, [dir])
+  return { dir, toggle }
+}
+

--- a/src/index.css
+++ b/src/index.css
@@ -117,3 +117,12 @@ All colors MUST be HSL.
     @apply bg-background text-foreground;
   }
 }
+
+@layer base {
+  [dir='rtl'] body {
+    direction: rtl;
+  }
+  [dir='rtl'] .text-left {
+    text-align: right;
+  }
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -2,7 +2,7 @@ import type { Config } from "tailwindcss";
 import animatePlugin from "tailwindcss-animate";
 
 export default {
-	darkMode: ["class"],
+        darkMode: 'class',
 	content: [
 		"./pages/**/*.{ts,tsx}",
 		"./components/**/*.{ts,tsx}",
@@ -18,8 +18,8 @@ export default {
 				'2xl': '1400px'
 			}
 		},
-		extend: {
-			colors: {
+                extend: {
+                        colors: {
 				border: 'hsl(var(--border))',
 				input: 'hsl(var(--input))',
 				ring: 'hsl(var(--ring))',
@@ -62,22 +62,41 @@ export default {
 					DEFAULT: 'hsl(var(--card))',
 					foreground: 'hsl(var(--card-foreground))'
 				},
-				sidebar: {
-					DEFAULT: 'hsl(var(--sidebar-background))',
-					foreground: 'hsl(var(--sidebar-foreground))',
-					primary: 'hsl(var(--sidebar-primary))',
-					'primary-foreground': 'hsl(var(--sidebar-primary-foreground))',
-					accent: 'hsl(var(--sidebar-accent))',
-					'accent-foreground': 'hsl(var(--sidebar-accent-foreground))',
-					border: 'hsl(var(--sidebar-border))',
-					ring: 'hsl(var(--sidebar-ring))'
-				}
-			},
-			borderRadius: {
-				lg: 'var(--radius)',
-				md: 'calc(var(--radius) - 2px)',
-				sm: 'calc(var(--radius) - 4px)'
-			},
+                                sidebar: {
+                                        DEFAULT: 'hsl(var(--sidebar-background))',
+                                        foreground: 'hsl(var(--sidebar-foreground))',
+                                        primary: 'hsl(var(--sidebar-primary))',
+                                        'primary-foreground': 'hsl(var(--sidebar-primary-foreground))',
+                                        accent: 'hsl(var(--sidebar-accent))',
+                                        'accent-foreground': 'hsl(var(--sidebar-accent-foreground))',
+                                        border: 'hsl(var(--sidebar-border))',
+                                        ring: 'hsl(var(--sidebar-ring))'
+                                }
+                        },
+                        spacing: {
+                                xs: '0.25rem',
+                                sm: '0.5rem',
+                                md: '1rem',
+                                lg: '1.5rem',
+                                xl: '2rem'
+                        },
+                        fontFamily: {
+                                sans: ['Inter', 'sans-serif'],
+                                serif: ['Merriweather', 'serif'],
+                                mono: ['Menlo', 'monospace']
+                        },
+                        fontSize: {
+                                xs: '0.75rem',
+                                sm: '0.875rem',
+                                base: '1rem',
+                                lg: '1.125rem',
+                                xl: '1.25rem'
+                        },
+                        borderRadius: {
+                                lg: 'var(--radius)',
+                                md: 'calc(var(--radius) - 2px)',
+                                sm: 'calc(var(--radius) - 4px)'
+                        },
 			keyframes: {
 				'accordion-down': {
 					from: {


### PR DESCRIPTION
## Summary
- extend Tailwind with theme tokens for color, spacing, and typography and enable class-based dark mode
- add shadcn variant utilities for Card and Tabs components
- implement theme toggle and RTL utilities including useRTL hook

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any... in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_689a6223362c8323ae97f339e39f2df8