### PR TITLE
Add role-based access control across app

### DIFF
--- a/src/components/RoleBasedRoute.tsx
+++ b/src/components/RoleBasedRoute.tsx
@@ -1,11 +1,11 @@
-import { useRole } from "@/hooks/useRole";
+import { useRole, type UserRole } from "@/hooks/useRole";
 import { Navigate } from "react-router-dom";
 import { Card, CardContent } from "@/components/ui/card";
-import { Loader2, Shield } from "lucide-react";
+import { Loader2 } from "lucide-react";
 
 interface RoleBasedRouteProps {
   children: React.ReactNode;
-  allowedRoles: string[];
+  allowedRoles: UserRole[];
   fallbackPath?: string;
 }
 
@@ -30,21 +30,7 @@ export function RoleBasedRoute({
   }
 
   if (!role || !allowedRoles.includes(role)) {
-    return (
-      <div className="min-h-[400px] flex items-center justify-center">
-        <Card className="w-full max-w-md">
-          <CardContent className="flex flex-col items-center justify-center p-8 space-y-4">
-            <Shield className="h-12 w-12 text-destructive" />
-            <div className="text-center space-y-2">
-              <h2 className="text-xl font-semibold text-destructive">אין הרשאה</h2>
-              <p className="text-muted-foreground">
-                אין לך הרשאה לגשת לעמוד זה
-              </p>
-            </div>
-          </CardContent>
-        </Card>
-      </div>
-    );
+    return <Navigate to={fallbackPath} replace />;
   }
 
   return <>{children}</>;

--- a/src/hooks/useRole.tsx
+++ b/src/hooks/useRole.tsx
@@ -3,16 +3,15 @@ import { useAuth } from '@/hooks/useAuth';
 import { supabase } from '@/integrations/supabase/client';
 import { toast } from '@/components/ui/use-toast';
 
-type UserRole = 'admin' | 'lawyer' | 'client' | 'supplier' | 'customer';
+export type UserRole = 'admin' | 'lead_provider' | 'lawyer' | 'customer';
 
 interface UserRoleData {
   role: UserRole | null;
   loading: boolean;
   hasPermission: (requiredRole: UserRole | UserRole[]) => boolean;
   isAdmin: boolean;
+  isLeadProvider: boolean;
   isLawyer: boolean;
-  isClient: boolean;
-  isSupplier: boolean;
   isCustomer: boolean;
 }
 
@@ -93,9 +92,8 @@ export function useRole(): UserRoleData {
     loading,
     hasPermission,
     isAdmin: role === 'admin',
+    isLeadProvider: role === 'lead_provider',
     isLawyer: role === 'lawyer',
-    isClient: role === 'client',
-    isSupplier: role === 'supplier',
     isCustomer: role === 'customer'
   };
 }

--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -7,6 +7,8 @@ import { useClients } from "@/hooks/useClients";
 import { useCases } from "@/hooks/useCases";
 import { useMeetings } from "@/hooks/useMeetings";
 import { useLeadDeposits } from "@/hooks/useDeposits";
+import { RoleBasedRoute } from "@/components/RoleBasedRoute";
+import type { UserRole } from "@/hooks/useRole";
 
 export default function AdminDashboard() {
   const { getLeadStats } = useLeads();
@@ -22,17 +24,18 @@ export default function AdminDashboard() {
   const depositStats = getDepositStats();
 
   return (
-    <div className="p-6 space-y-6">
-      <div className="flex justify-between items-center">
-        <div>
-          <h1 className="text-3xl font-bold">Admin Panel</h1>
-          <p className="text-muted-foreground">Overview of system activity</p>
+    <RoleBasedRoute allowedRoles={["admin"] as UserRole[]}>
+      <div className="p-6 space-y-6">
+        <div className="flex justify-between items-center">
+          <div>
+            <h1 className="text-3xl font-bold">Admin Panel</h1>
+            <p className="text-muted-foreground">Overview of system activity</p>
+          </div>
+          <Button variant="outline">
+            <Settings className="h-4 w-4 mr-2" />
+            System Settings
+          </Button>
         </div>
-        <Button variant="outline">
-          <Settings className="h-4 w-4 mr-2" />
-          System Settings
-        </Button>
-      </div>
 
       {/* Key Metrics */}
       <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
@@ -187,5 +190,6 @@ export default function AdminDashboard() {
         </CardContent>
       </Card>
     </div>
+    </RoleBasedRoute>
   );
 }

--- a/supabase/functions/assignment-notification/index.ts
+++ b/supabase/functions/assignment-notification/index.ts
@@ -15,6 +15,10 @@ serve(async (req) => {
   if (req.method === 'OPTIONS') {
     return new Response(null, { headers: corsHeaders });
   }
+  const role = (req as Request & { auth?: { user?: { role?: string } } }).auth?.user?.role;
+  if (role !== 'admin') {
+    return new Response(JSON.stringify({ error: 'Forbidden' }), { status: 403, headers: corsHeaders });
+  }
 
   try {
     logStep("Function started");

--- a/supabase/functions/court-document-upload/index.ts
+++ b/supabase/functions/court-document-upload/index.ts
@@ -10,6 +10,10 @@ serve(async (req) => {
   if (req.method === 'OPTIONS') {
     return new Response(null, { headers: corsHeaders });
   }
+  const role = (req as Request & { auth?: { user?: { role?: string } } }).auth?.user?.role;
+  if (role !== 'admin') {
+    return new Response(JSON.stringify({ error: 'Forbidden' }), { status: 403, headers: corsHeaders });
+  }
 
   try {
     const token = req.headers.get('Authorization')?.replace('Bearer ', '');

--- a/supabase/functions/court-reminder/index.ts
+++ b/supabase/functions/court-reminder/index.ts
@@ -10,6 +10,10 @@ serve(async (req) => {
   if (req.method === 'OPTIONS') {
     return new Response(null, { headers: corsHeaders });
   }
+  const role = (req as Request & { auth?: { user?: { role?: string } } }).auth?.user?.role;
+  if (role !== 'admin') {
+    return new Response(JSON.stringify({ error: 'Forbidden' }), { status: 403, headers: corsHeaders });
+  }
 
   try {
     const token = req.headers.get('Authorization')?.replace('Bearer ', '');

--- a/supabase/functions/create-payment/index.ts
+++ b/supabase/functions/create-payment/index.ts
@@ -7,7 +7,7 @@ const corsHeaders = {
   "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
 };
 
-const logStep = (step: string, details?: any) => {
+const logStep = (step: string, details?: Record<string, unknown>) => {
   const detailsStr = details ? ` - ${JSON.stringify(details)}` : '';
   console.log(`[CREATE-PAYMENT] ${step}${detailsStr}`);
 };
@@ -15,6 +15,10 @@ const logStep = (step: string, details?: any) => {
 serve(async (req) => {
   if (req.method === "OPTIONS") {
     return new Response(null, { headers: corsHeaders });
+  }
+  const role = (req as Request & { auth?: { user?: { role?: string } } }).auth?.user?.role;
+  if (role !== 'admin') {
+    return new Response(JSON.stringify({ error: 'Forbidden' }), { status: 403, headers: corsHeaders });
   }
 
   try {

--- a/supabase/functions/google-calendar-sync/index.ts
+++ b/supabase/functions/google-calendar-sync/index.ts
@@ -19,6 +19,10 @@ serve(async (req) => {
   if (req.method === 'OPTIONS') {
     return new Response(null, { headers: corsHeaders });
   }
+  const role = (req as Request & { auth?: { user?: { role?: string } } }).auth?.user?.role;
+  if (role !== 'admin') {
+    return new Response(JSON.stringify({ error: 'Forbidden' }), { status: 403, headers: corsHeaders });
+  }
 
   try {
     const { action, event, accessToken } = await req.json();

--- a/supabase/migrations/20250814120000_add_role_checks_to_profiles.sql
+++ b/supabase/migrations/20250814120000_add_role_checks_to_profiles.sql
@@ -1,0 +1,32 @@
+-- Ensure role column and policies for profiles
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS role TEXT NOT NULL DEFAULT 'customer'
+  CHECK (role IN ('admin','lead_provider','lawyer','customer'));
+
+DROP POLICY IF EXISTS "Users can view their own profile" ON public.profiles;
+CREATE POLICY "Users can view their own profile" ON public.profiles
+  FOR SELECT TO authenticated
+  USING (user_id = auth.uid());
+
+DROP POLICY IF EXISTS "Admins can view all profiles" ON public.profiles;
+CREATE POLICY "Admins can view all profiles" ON public.profiles
+  FOR SELECT TO authenticated
+  USING (get_current_user_role() = 'admin');
+
+DROP POLICY IF EXISTS "Users can update their own profile (except role)" ON public.profiles;
+CREATE POLICY "Users can update their own profile (except role)" ON public.profiles
+  FOR UPDATE TO authenticated
+  USING (auth.uid() = user_id)
+  WITH CHECK (
+    auth.uid() = user_id
+    AND role = (SELECT role FROM public.profiles WHERE user_id = auth.uid())
+  );
+
+DROP POLICY IF EXISTS "Admins can update any profile" ON public.profiles;
+CREATE POLICY "Admins can update any profile" ON public.profiles
+  FOR ALL TO authenticated
+  USING (get_current_user_role() = 'admin')
+  WITH CHECK (get_current_user_role() = 'admin');
+
+ALTER TABLE public.profiles ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.profiles FORCE ROW LEVEL SECURITY;


### PR DESCRIPTION
## Summary
- enforce role field and RLS policies on profiles table
- expose user roles in hook and guard admin routes
- validate user roles in serverless functions

## Testing
- `npm test`
- `npm run lint` (fails: Unexpected any in src/pages/Settings.tsx and supabase/functions/ai-court-orchestrator/index.ts)


------
https://chatgpt.com/codex/tasks/task_e_689a6226067483239bfe50709f1c4ec0