### PR TITLE
Add evidence version storage and search

### DIFF
--- a/src/components/court/EvidencePrep.tsx
+++ b/src/components/court/EvidencePrep.tsx
@@ -1,108 +1,80 @@
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
 import { useToast } from "@/hooks/use-toast";
 import BiasReportButton from "./BiasReportButton";
+import { uploadCourtDocument, searchEvidence } from "@/lib/api";
 
-interface EvidenceItem {
+interface EvidenceRecord {
   id: string;
-  title: string;
-  url?: string;
-  notes?: string;
-  category?: string;
-  votes: number;
+  document_url: string | null;
+  description: string | null;
+  evidence_text: string | null;
 }
 
 const EvidencePrep = () => {
   const { toast } = useToast();
-  const [title, setTitle] = useState("");
-  const [url, setUrl] = useState("");
-  const [category, setCategory] = useState("");
-  const [notes, setNotes] = useState("");
-  const [items, setItems] = useState<EvidenceItem[]>([]);
+  const [file, setFile] = useState<File | null>(null);
+  const [description, setDescription] = useState("");
   const [q, setQ] = useState("");
+  const [results, setResults] = useState<EvidenceRecord[]>([]);
 
-  const addItem = (e: React.FormEvent) => {
+  const addItem = async (e: React.FormEvent) => {
     e.preventDefault();
-    const id = Math.random().toString(36).slice(2, 10);
-    const newItem: EvidenceItem = { id, title, url: url || undefined, notes: notes || undefined, category: category || undefined, votes: 0 };
-    setItems((prev) => [newItem, ...prev]);
-    setTitle(""); setUrl(""); setCategory(""); setNotes("");
-    toast({ title: "Evidence added", description: "Item added to the collaborative board." });
+    if (!file) return;
+    await uploadCourtDocument({ caseId: "demo", file, description });
+    setFile(null); setDescription("");
+    toast({ title: "Uploaded" });
   };
 
-  const vote = (id: string, delta: number) => {
-    setItems((prev) => prev.map((it) => it.id === id ? { ...it, votes: Math.max(0, it.votes + delta) } : it));
+  const runSearch = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const data = await searchEvidence(q);
+    setResults(data?.data ?? data);
   };
-
-  const results = useMemo(() => {
-    const text = q.toLowerCase();
-    return items.filter((i) => `${i.title} ${i.category ?? ''} ${i.notes ?? ''}`.toLowerCase().includes(text));
-  }, [items, q]);
 
   return (
     <div className="space-y-4">
       <form className="grid gap-3 md:grid-cols-4" onSubmit={addItem} aria-label="Add evidence form">
         <div className="space-y-2 md:col-span-2">
-          <Label htmlFor="ev-title">Title</Label>
-          <Input id="ev-title" value={title} onChange={(e) => setTitle(e.target.value)} required placeholder="Contract PDF, Photo, Email, etc." />
-        </div>
-        <div className="space-y-2">
-          <Label htmlFor="ev-url">Link (optional)</Label>
-          <Input id="ev-url" type="url" value={url} onChange={(e) => setUrl(e.target.value)} placeholder="https://..." />
-        </div>
-        <div className="space-y-2">
-          <Label htmlFor="ev-cat">Category</Label>
-          <Input id="ev-cat" value={category} onChange={(e) => setCategory(e.target.value)} placeholder="Documents, Photos, Messages..." />
+          <Label htmlFor="ev-file">File</Label>
+          <Input id="ev-file" type="file" onChange={(e) => setFile(e.target.files?.[0] ?? null)} required />
         </div>
         <div className="space-y-2 md:col-span-4">
-          <Label htmlFor="ev-notes">Notes</Label>
-          <Textarea id="ev-notes" value={notes} onChange={(e) => setNotes(e.target.value)} placeholder="Context, relevance, and chain-of-custody notes." />
+          <Label htmlFor="ev-notes">Description</Label>
+          <Textarea id="ev-notes" value={description} onChange={(e) => setDescription(e.target.value)} />
         </div>
         <div className="md:col-span-4">
-          <Button type="submit">Add to board</Button>
+          <Button type="submit">Upload</Button>
         </div>
       </form>
 
-      <div className="space-y-3">
+      <form className="space-y-3" onSubmit={runSearch} aria-label="Search evidence">
         <div className="space-y-2">
           <Label htmlFor="ev-search">Search evidence</Label>
-          <Input id="ev-search" value={q} onChange={(e) => setQ(e.target.value)} placeholder="Keyword, category..." />
+          <Input id="ev-search" value={q} onChange={(e) => setQ(e.target.value)} placeholder="Keyword" />
         </div>
+        <Button type="submit">Search</Button>
+      </form>
 
-        <div className="grid gap-3 md:grid-cols-2 lg:grid-cols-3">
-          {results.map((it) => (
-            <Card key={it.id}>
-              <CardContent className="p-4 space-y-2">
-                <div className="flex items-center justify-between">
-                  <p className="font-medium">{it.title}</p>
-                  <div className="flex items-center gap-2">
-                    {it.category && <Badge variant="outline">{it.category}</Badge>}
-                    <Badge variant="secondary">{it.votes} votes</Badge>
-                  </div>
-                </div>
-                {it.url && (
-                  <a className="text-sm underline" href={it.url} target="_blank" rel="noreferrer noopener"
-                     aria-label={`Open evidence ${it.title}`}>{it.url}</a>
-                )}
-                {it.notes && <p className="text-sm text-muted-foreground">{it.notes}</p>}
-                <div className="flex gap-2">
-                  <Button size="sm" variant="outline" onClick={() => vote(it.id, +1)}>Upvote</Button>
-                  <Button size="sm" variant="ghost" onClick={() => vote(it.id, -1)}>Downvote</Button>
-                </div>
-              </CardContent>
-            </Card>
-          ))}
-        </div>
+      <div className="grid gap-3 md:grid-cols-2 lg:grid-cols-3">
+        {results.map((it) => (
+          <Card key={it.id}>
+            <CardContent className="p-4 space-y-2">
+              {it.description && <p className="font-medium">{it.description}</p>}
+              {it.document_url && <p className="text-sm break-all">{it.document_url}</p>}
+              {it.evidence_text && <p className="text-sm text-muted-foreground max-h-40 overflow-y-auto">{it.evidence_text}</p>}
+            </CardContent>
+          </Card>
+        ))}
       </div>
 
       <div>
         <p className="text-xs text-muted-foreground">
-          Public demo: uploads are link-based for now. Verified submissions, digital signatures, and secure storage will be added next.
+          Public demo only.
         </p>
         <BiasReportButton context="evidence" />
       </div>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -6,8 +6,24 @@ export const addCourtReminder = async (payload: { caseId: string; remindAt: stri
   return data;
 };
 
-export const uploadCourtDocument = async (payload: { caseId: string; documentUrl: string; description?: string }) => {
-  const { data, error } = await supabase.functions.invoke('court-document-upload', { body: payload });
+export const uploadCourtDocument = async (payload: { caseId: string; file: File; description?: string }) => {
+  const array = await payload.file.arrayBuffer();
+  const base64 = btoa(String.fromCharCode(...new Uint8Array(array)));
+  const { data, error } = await supabase.functions.invoke('court-document-upload', {
+    body: {
+      caseId: payload.caseId,
+      fileName: payload.file.name,
+      fileContent: base64,
+      contentType: payload.file.type,
+      description: payload.description
+    }
+  });
+  if (error) throw error;
+  return data;
+};
+
+export const searchEvidence = async (query: string) => {
+  const { data, error } = await supabase.functions.invoke('evidence-search', { body: { query } });
   if (error) throw error;
   return data;
 };

--- a/supabase/migrations/20250812090000_create_evidence_versions.sql
+++ b/supabase/migrations/20250812090000_create_evidence_versions.sql
@@ -1,0 +1,11 @@
+CREATE TABLE public.evidence_versions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id),
+  case_id UUID REFERENCES public.cases(id),
+  document_url TEXT,
+  description TEXT,
+  evidence_text TEXT,
+  created_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE INDEX evidence_versions_text_idx ON public.evidence_versions USING GIN (to_tsvector('english', evidence_text));


### PR DESCRIPTION
## Summary
- create `evidence_versions` table to hold OCR text for uploaded evidence
- extend court document upload function to store files, run OCR, and insert versions
- add evidence search function and UI with API helpers

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any and other pre-existing issues)*
- `npx eslint src/components/court/EvidencePrep.tsx src/lib/api.ts supabase/functions/court-document-upload/index.ts supabase/functions/evidence-search/index.ts`


------
https://chatgpt.com/codex/tasks/task_e_689a622bac3483239742a70ef93730dd