### PR TITLE
feat: add realtime case updates

### DIFF
--- a/src/pages/CaseDetails.tsx
+++ b/src/pages/CaseDetails.tsx
@@ -27,11 +27,12 @@ export default function CaseDetails() {
 
   useEffect(() => {
     if (caseData) {
-      setEditData({
+      setEditData(prev => ({
+        ...prev,
         status: caseData.status,
         priority: caseData.priority,
         notes: caseData.notes || ''
-      });
+      }));
     }
   }, [caseData]);
 


### PR DESCRIPTION
## Summary
- add realtime channel for cases and update react-query cache
- sync local case draft across clients via Supabase broadcast
- merge realtime case changes into CaseDetails edit state

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any and ts-ignore issues)*

------
https://chatgpt.com/codex/tasks/task_e_689a6237486483239eb5ddb6d3051cb1