### PR TITLE
feat: sync hearings with google calendar

### DIFF
--- a/supabase/migrations/20250811120000_add_google_event_id_to_hearings.sql
+++ b/supabase/migrations/20250811120000_add_google_event_id_to_hearings.sql
@@ -1,0 +1,3 @@
+ALTER TABLE public.hearings
+ADD COLUMN google_event_id text;
+


### PR DESCRIPTION
## Summary
- add webhook and reconciliation logic to google calendar sync edge function
- trigger calendar sync after meeting creation
- store calendar event ids on hearings table

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any...)*

------
https://chatgpt.com/codex/tasks/task_e_689a6232b680832392babbf174388fb6