### PR TITLE
refactor: configure smart intake fields

### DIFF
--- a/src/components/court/SmartIntakePortal.tsx
+++ b/src/components/court/SmartIntakePortal.tsx
@@ -20,22 +20,11 @@ import AIConnectionTest from './AIConnectionTest';
 import { useAIAssistedIntake } from '@/aiIntake/useAIAssistedIntake';
 import { AIFieldsDisplay } from '@/aiIntake/AIFieldsDisplay';
 import AIBridge from '@/aiIntake/AIBridge';
-import { FIELD_MAP, REQUIRED_FIELDS } from '@/aiIntake/fieldMap';
 import { useFormWithAI } from '@/aiIntake/useFormWithAI';
-import { 
-  CaseTitleField, 
-  CaseSummaryField, 
-  JurisdictionField, 
-  CategoryField, 
-  GoalField, 
-  PartiesField, 
-  EvidenceField, 
-  TimelineField 
-} from '@/aiIntake/ControlledFormFields';
-import { 
-  MessageSquare, 
-  Users, 
-  Globe, 
+import {
+  MessageSquare,
+  Users,
+  Globe,
   FileText, 
   Calendar, 
   CreditCard, 
@@ -78,6 +67,17 @@ interface FieldStatus {
   status: 'incomplete' | 'partial' | 'complete';
   message: string;
 }
+
+const fieldsConfig = [
+  { id: 'caseTitle', label: 'Case Title', type: 'text', required: true, allowAttachments: false, options: [], dependsOn: null },
+  { id: 'jurisdiction', label: 'Jurisdiction', type: 'text', required: true, allowAttachments: false, options: [], dependsOn: null },
+  { id: 'category', label: 'Category', type: 'select', required: true, allowAttachments: false, options: ['Criminal', 'Civil', 'Family', 'Labor'], dependsOn: null },
+  { id: 'caseSummary', label: 'Case Summary', type: 'textarea', required: true, allowAttachments: true, options: [], dependsOn: null },
+  { id: 'goal', label: 'Goal', type: 'text', required: false, allowAttachments: false, options: [], dependsOn: null },
+  { id: 'parties', label: 'Parties', type: 'text', required: true, allowAttachments: false, options: [], dependsOn: null },
+  { id: 'evidence', label: 'Evidence', type: 'textarea', required: false, allowAttachments: true, options: [], dependsOn: null },
+  { id: 'timeline', label: 'Timeline', type: 'textarea', required: false, allowAttachments: false, options: [], dependsOn: null }
+];
 
 const SmartIntakePortal = () => {
   const { toast } = useToast();
@@ -582,23 +582,31 @@ const SmartIntakePortal = () => {
                   <CardTitle>Case Details</CardTitle>
                 </CardHeader>
                 <CardContent className="space-y-6">
-                  <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                    <CaseTitleField />
-                    <JurisdictionField />
-                  </div>
-                  
-                  <CategoryField />
-                  
-                  <CaseSummaryField />
-                  
-                  <GoalField />
-                  
-                  <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                    <PartiesField />
-                    <EvidenceField />
-                  </div>
-                  
-                  <TimelineField />
+                  {fieldsConfig.map(field => {
+                    if (field.dependsOn && !form.watch(field.dependsOn)) return null
+                    return (
+                      <div key={field.id} className="space-y-2">
+                        <label htmlFor={field.id} className="text-sm font-medium">{field.label}</label>
+                        {field.type === 'textarea' ? (
+                          <Textarea id={field.id} {...form.register(field.id, { required: field.required })} />
+                        ) : field.type === 'select' ? (
+                          <Select value={form.watch(field.id)} onValueChange={value => form.setValue(field.id, value)}>
+                            <SelectTrigger>
+                              <SelectValue placeholder={field.label} />
+                            </SelectTrigger>
+                            <SelectContent>
+                              {field.options.map(option => (
+                                <SelectItem key={option} value={option}>{option}</SelectItem>
+                              ))}
+                            </SelectContent>
+                          </Select>
+                        ) : (
+                          <Input id={field.id} type="text" {...form.register(field.id, { required: field.required })} />
+                        )}
+                        {field.allowAttachments && <Input type="file" multiple />}
+                      </div>
+                    )
+                  })}
                 </CardContent>
               </Card>
 


### PR DESCRIPTION
## Summary
- add configurable `fieldsConfig` for intake portal
- render form fields dynamically from configuration

## Testing
- `npm run lint` *(fails: Unexpected any in multiple files)*
- `npm run typecheck`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a039eeaad08323a200b3f90c613be7