### PR TITLE
Add dynamic field management to SmartIntakePortal

### DIFF
--- a/src/components/court/SmartIntakePortal.tsx
+++ b/src/components/court/SmartIntakePortal.tsx
@@ -120,6 +120,7 @@ const SmartIntakePortal = () => {
   const [liveSuggestions, setLiveSuggestions] = useState<Record<string, any>>({});
   const [approvedFields, setApprovedFields] = useState<Record<string, boolean>>({});
   const [isLiveExtracting, setIsLiveExtracting] = useState(false);
+  const [fieldsConfig, setFieldsConfig] = useState<{ id: string }[]>([]);
 
   // HF token (memory-only)
   const [hfToken, setHfToken] = useState('');
@@ -288,6 +289,14 @@ const SmartIntakePortal = () => {
       return rest;
     });
     toast({ title: 'Field updated', description: `${key} approved from AI suggestion` });
+  };
+
+  const addDynamicField = (fieldConfig: { id: string }) => {
+    setFieldsConfig(prev =>
+      prev.some(field => field.id === fieldConfig.id)
+        ? prev
+        : [...prev, fieldConfig]
+    );
   };
 
   const applyAIFields = (fieldsToApply: Record<string, any>) => {


### PR DESCRIPTION
## Summary
- track dynamic field configurations in SmartIntakePortal
- add helper to append unique field configs

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68a039f04fdc8323bdcea7f8ef491fba