### PR TITLE
feat: return additionalFields for contract or overtime terms

### DIFF
--- a/supabase/functions/ai-court-orchestrator/index.ts
+++ b/supabase/functions/ai-court-orchestrator/index.ts
@@ -228,7 +228,7 @@ serve(async (req) => {
 
       // Try HF fallback
       const prompt = `Create an IRAC-based intake in ${locale}.
-Return STRICT JSON with keys: intro, method, questions (array of {id,text,type,options?}), disclaimer.
+Return STRICT JSON with keys: intro, method, questions (array of {id,text,type,options?}), disclaimer. If the text includes "breach of contract" or "overtime unpaid" include additionalFields { breachOfContract: boolean, overtimeUnpaid: boolean }.
 Consider context: ${JSON.stringify(body.context || {})}`;
       const gen = await callModelViaHF(prompt, (body as any).model, (body as any).hf_token);
       if (gen) {


### PR DESCRIPTION
## Summary
- extend intake prompt to include `additionalFields` when text mentions breach of contract or unpaid overtime

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any, prefer-const)*

------
https://chatgpt.com/codex/tasks/task_e_68a039f0ec9c8323ad12ed13a8484646