### PR TITLE
handle ai additional fields

### DIFF
--- a/src/aiIntake/openaiIntakeClient.ts
+++ b/src/aiIntake/openaiIntakeClient.ts
@@ -11,6 +11,7 @@ export type IntakeJson = {
   timeline?: string;
   nextQuestion?: string;
   confidence?: Record<string, number>;
+  additionalFields?: Record<string, { value?: string; confidence?: number }>;
 };
 
 export async function runIntake(messages: {role:"system"|"user"|"assistant";content:string}[]): Promise<IntakeJson> {


### PR DESCRIPTION
## Summary
- Parse `additionalFields` from AI intake responses
- Add dynamic field handling with edit/approve state and dirty checks

## Testing
- `npm test` *(fails: no output)*
- `npm run lint` *(fails: Unexpected any etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68a039f34f408323a5cdf88a5bdb8231