### PR TITLE
feat: enable evidence uploads

### DIFF
--- a/src/aiIntake/ControlledFormFields.tsx
+++ b/src/aiIntake/ControlledFormFields.tsx
@@ -4,6 +4,7 @@ import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Label } from '@/components/ui/label';
+import EvidenceUploader from '@/components/EvidenceUploader';
 
 const jurisdictions = [
   'Federal Court',
@@ -168,8 +169,9 @@ export function PartiesField() {
 }
 
 export function EvidenceField() {
-  const { control } = useFormContext();
-  
+  const { control, watch } = useFormContext();
+  const caseId = watch('id')
+
   return (
     <div className="space-y-2">
       <Label htmlFor="evidence" className="text-sm font-medium">Evidence</Label>
@@ -186,6 +188,7 @@ export function EvidenceField() {
           />
         )}
       />
+      <EvidenceUploader caseId={caseId || 'draft'} fieldId="evidence" />
     </div>
   );
 }

--- a/src/components/EvidenceUploader.tsx
+++ b/src/components/EvidenceUploader.tsx
@@ -1,29 +1,45 @@
-import { useState } from 'react';
-import { uploadToSignedUrl } from '@/services/evidence';
+import { useState } from 'react'
+import { Input } from '@/components/ui/input'
+import { supabase } from '@/integrations/supabase/client'
 
-interface EvidenceUploaderProps {
-  signedUrl: string;
+interface Props {
+  caseId: string
+  fieldId: string
 }
 
-export function EvidenceUploader({ signedUrl }: EvidenceUploaderProps) {
-  const [error, setError] = useState('');
+export function EvidenceUploader({ caseId, fieldId }: Props) {
+  const [fileName, setFileName] = useState('')
+  const [status, setStatus] = useState('')
 
   const handleChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (!file) return;
-    try {
-      await uploadToSignedUrl(signedUrl, file);
-    } catch (err) {
-      setError((err as Error).message);
-    }
-  };
+    const file = e.target.files?.[0]
+    if (!file) return
+    const buffer = await file.arrayBuffer()
+    const hashBuffer = await crypto.subtle.digest('SHA-256', buffer)
+    const hashArray = Array.from(new Uint8Array(hashBuffer))
+    const hash = hashArray.map(b => b.toString(16).padStart(2, '0')).join('')
+    const path = `${caseId}/${fieldId}/${Date.now()}-${file.name}`
+    const { error } = await supabase.storage.from('case-files').upload(path, file)
+    if (error) return
+    const { data: urlData } = supabase.storage.from('case-files').getPublicUrl(path)
+    await supabase.from('case_evidence').insert({
+      case_id: caseId,
+      field_id: fieldId,
+      file_url: urlData.publicUrl,
+      hash,
+      uploaded_at: new Date().toISOString()
+    })
+    setFileName(file.name)
+    setStatus('הועלה')
+  }
 
   return (
-    <div>
-      <input type="file" onChange={handleChange} />
-      {error && <p>{error}</p>}
+    <div className="flex items-center gap-2">
+      <Input type="file" onChange={handleChange} />
+      {fileName && <span className="text-sm">{fileName} - {status}</span>}
     </div>
-  );
+  )
 }
 
-export default EvidenceUploader;
+export default EvidenceUploader
+


### PR DESCRIPTION
## Summary
- add evidence uploader that stores files in Supabase Storage and records hashes
- attach evidence uploader to form field allowing attachments

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any...)*

------
https://chatgpt.com/codex/tasks/task_e_68a039f4a22083239a2e7ff70b630925