### PR TITLE
Add professional lookup and invitation flow

### DIFF
--- a/src/components/court/SmartIntakePortal.tsx
+++ b/src/components/court/SmartIntakePortal.tsx
@@ -7,6 +7,7 @@ import { InviteManager } from '@/components/social/InviteManager';
 import { PollManager } from '@/components/polls/PollManager';
 import { SubscriptionManager } from '@/components/subscription/SubscriptionManager';
 import { ProfessionalMarketplace } from '@/components/professionals/ProfessionalMarketplace';
+import { ProfessionalSuggestions } from '@/components/professionals/ProfessionalSuggestions';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { Badge } from '@/components/ui/badge';
@@ -606,7 +607,7 @@ const SmartIntakePortal = () => {
               <Card>
                 <CardContent className="p-4">
                   <div className="flex gap-4">
-                    <Button 
+                    <Button
                       onClick={generateCase}
                       disabled={readinessStatus.score < 80}
                       className="flex-1"
@@ -621,6 +622,15 @@ const SmartIntakePortal = () => {
                   </div>
                 </CardContent>
               </Card>
+
+              {aiFields.jurisdiction?.status === 'approved' && aiFields.legalCategory?.status === 'approved' && (
+                <ProfessionalSuggestions
+                  caseId="demo-case"
+                  jurisdiction={aiFields.jurisdiction.value}
+                  specialization={aiFields.legalCategory.value}
+                  role="lawyer"
+                />
+              )}
             </div>
           </div>
         </div>

--- a/src/components/professionals/ProfessionalSuggestions.tsx
+++ b/src/components/professionals/ProfessionalSuggestions.tsx
@@ -1,0 +1,89 @@
+import { useEffect, useState } from 'react'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { InviteManager } from '@/components/social/InviteManager'
+import { supabase } from '@/integrations/supabase/client'
+
+type Professional = {
+  profile_id: string
+  full_name: string
+  role: string
+  location: string | null
+  specializations: string[]
+  rating: number | null
+}
+
+interface ProfessionalSuggestionsProps {
+  caseId: string
+  jurisdiction: string
+  specialization: string
+  role: string
+}
+
+export function ProfessionalSuggestions({ caseId, jurisdiction, specialization, role }: ProfessionalSuggestionsProps) {
+  const [professionals, setProfessionals] = useState<Professional[]>([])
+  const [loading, setLoading] = useState(false)
+  const [selected, setSelected] = useState<Professional | null>(null)
+
+  useEffect(() => {
+    if (!jurisdiction || !specialization) return
+    setLoading(true)
+    supabase.functions.invoke('get-professionals', {
+      body: { role, specialization, jurisdiction }
+    }).then(({ data }) => {
+      setProfessionals(data || [])
+    }).finally(() => setLoading(false))
+  }, [jurisdiction, specialization, role])
+
+  const invite = async (pro: Professional) => {
+    await supabase.from('case_parties').insert({ case_id: caseId, profile_id: pro.profile_id, role: pro.role })
+    setSelected(pro)
+  }
+
+  if (loading) {
+    return <p>Loading professionals...</p>
+  }
+
+  if (professionals.length === 0) {
+    return null
+  }
+
+  return (
+    <div className="space-y-4">
+      <h3 className="font-semibold">Suggested Professionals</h3>
+      <div className="grid gap-4 md:grid-cols-2">
+        {professionals.map(pro => (
+          <Card key={pro.profile_id}>
+            <CardHeader>
+              <CardTitle className="flex items-center justify-between">
+                <span>{pro.full_name}</span>
+                <Badge>{pro.role}</Badge>
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-2">
+              <div className="text-sm text-muted-foreground">{pro.location || 'Global'}</div>
+              <div className="flex flex-wrap gap-1">
+                {pro.specializations.map(s => (
+                  <Badge key={s} variant="outline">{s}</Badge>
+                ))}
+              </div>
+              <Button size="sm" onClick={() => invite(pro)}>Invite</Button>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+      <Dialog open={!!selected} onOpenChange={open => !open && setSelected(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Send Invitation</DialogTitle>
+          </DialogHeader>
+          {selected && (
+            <InviteManager caseId={caseId} caseTitle={`Case ${caseId}`} onInviteSent={() => setSelected(null)} />
+          )}
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}

--- a/supabase/functions/get-professionals/index.ts
+++ b/supabase/functions/get-professionals/index.ts
@@ -1,0 +1,49 @@
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+}
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') return new Response(null, { headers: corsHeaders })
+
+  try {
+    const supabaseUrl = Deno.env.get('SUPABASE_URL')
+    const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')
+
+    if (!supabaseUrl || !supabaseServiceKey) {
+      return new Response(JSON.stringify({ error: 'Missing configuration' }), { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } })
+    }
+
+    const supabase = createClient(supabaseUrl, supabaseServiceKey)
+    const { role, specialization, jurisdiction } = await req.json()
+
+    let query = supabase
+      .from('lawyers')
+      .select('profile_id, location, specializations, rating, profiles!inner(full_name, role)')
+
+    if (jurisdiction) query = query.ilike('location', `%${jurisdiction}%`)
+    if (specialization) query = query.contains('specializations', [specialization])
+    if (role) query = query.eq('profiles.role', role)
+
+    const { data, error } = await query
+    if (error) {
+      return new Response(JSON.stringify({ error: error.message }), { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } })
+    }
+
+    const professionals = (data || []).map(item => ({
+      profile_id: item.profile_id,
+      full_name: item.profiles.full_name,
+      role: item.profiles.role,
+      location: item.location,
+      specializations: item.specializations || [],
+      rating: item.rating
+    }))
+
+    return new Response(JSON.stringify(professionals), { headers: { ...corsHeaders, 'Content-Type': 'application/json' } })
+  } catch (err) {
+    return new Response(JSON.stringify({ error: err.message }), { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } })
+  }
+})


### PR DESCRIPTION
## Summary
- add `get-professionals` edge function querying by role, specialization and jurisdiction
- show suggested professionals once jurisdiction and category approved
- allow inviting a professional which records case party and opens InviteManager

## Testing
- `npm test -- --run`
- `npm run lint` *(fails: Unexpected any, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a039f7e8788323be6714e0c35be8b7