### PR TITLE
feat: add case draft creation and invite

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -38,6 +38,7 @@ import Intake from "./pages/Intake";
 import HearingJoin from "./pages/HearingJoin";
 import GptOssPortal from "./pages/GptOssPortal";
 import ChatPortal from "./features/ai/ChatPortal";
+import DefendantIntake from "./pages/DefendantIntake";
 
 const App = () => (
   <ThemeProvider attribute="class" defaultTheme="light" enableSystem>
@@ -56,6 +57,7 @@ const App = () => (
                 <Route path="/gpt-oss" element={<GptOssPortal />} />
                 <Route path="/ai-portal" element={<ChatPortal />} />
                 <Route path="/intake" element={<Intake />} />
+                <Route path="/defendant-intake" element={<DefendantIntake />} />
                 <Route path="/" element={<GlobalCourt />} />
                 
                 {/* Protected Routes */}

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -167,6 +167,8 @@ export type Database = {
           created_at: string | null
           estimated_budget: number | null
           id: string
+          case_number: string | null
+          invite_token: string | null
           legal_category: string
           notes: string | null
           opened_at: string | null
@@ -181,6 +183,8 @@ export type Database = {
           created_at?: string | null
           estimated_budget?: number | null
           id?: string
+          case_number?: string | null
+          invite_token?: string | null
           legal_category: string
           notes?: string | null
           opened_at?: string | null
@@ -195,6 +199,8 @@ export type Database = {
           created_at?: string | null
           estimated_budget?: number | null
           id?: string
+          case_number?: string | null
+          invite_token?: string | null
           legal_category?: string
           notes?: string | null
           opened_at?: string | null

--- a/src/pages/DefendantIntake.tsx
+++ b/src/pages/DefendantIntake.tsx
@@ -1,0 +1,34 @@
+import { useEffect, useState } from 'react'
+import SmartIntakePortal from '@/components/court/SmartIntakePortal'
+import { supabase } from '@/integrations/supabase/client'
+
+const DefendantIntake = () => {
+  const [ready, setReady] = useState(false)
+  useEffect(() => {
+    const load = async () => {
+      const params = new URLSearchParams(window.location.search)
+      const token = params.get('token')
+      if (token) {
+        const { data } = await supabase.from('cases').select('id,title,legal_category,notes').eq('invite_token', token).single()
+        if (data) {
+          const draft = {
+            title: data.title,
+            summary: data.notes || '',
+            jurisdiction: '',
+            category: data.legal_category,
+            goal: '',
+            parties: '',
+            evidence: '',
+            timeline: ''
+          }
+          localStorage.setItem('caseDraft', JSON.stringify(draft))
+        }
+      }
+      setReady(true)
+    }
+    load()
+  }, [])
+  if (!ready) return null
+  return <SmartIntakePortal />
+}
+export default DefendantIntake

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -68,3 +68,6 @@ verify_jwt = false
 
 [functions.ai-intake-openai]
 verify_jwt = false
+
+[functions.createCaseDraft]
+verify_jwt = false

--- a/supabase/functions/createCaseDraft/index.ts
+++ b/supabase/functions/createCaseDraft/index.ts
@@ -1,0 +1,37 @@
+import { serve } from "https://deno.land/std@0.177.0/http/server.ts"
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2"
+
+const corsHeaders = {
+ "Access-Control-Allow-Origin": "*",
+ "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type"
+}
+
+serve(async req => {
+ if (req.method === "OPTIONS") return new Response(null, { headers: corsHeaders })
+ const supabase = createClient(Deno.env.get("SUPABASE_URL")!, Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!)
+ const body = await req.json()
+ const title = body.title || "Draft"
+ const category = body.legal_category || "general"
+ const case_number = `C-${Date.now()}`
+ const token = crypto.randomUUID()
+ const { data, error } = await supabase.from("cases").insert({ title, legal_category: category, status: "draft", case_number, invite_token: token }).select("id").single()
+ if (error) return new Response(JSON.stringify({ error: error.message }), { status: 400, headers: { ...corsHeaders, "Content-Type": "application/json" } })
+ const link = `${Deno.env.get("SITE_URL")}/defendant-intake?token=${token}`
+ if (body.email) await sendEmail(body.email, link)
+ if (body.phone) await sendWhatsAppMessage(body.phone, link)
+ return new Response(JSON.stringify({ case_id: data.id, case_number }), { headers: { ...corsHeaders, "Content-Type": "application/json" } })
+})
+
+async function sendEmail(to: string, link: string) {
+ const url = Deno.env.get("EMAIL_API_URL")
+ const key = Deno.env.get("EMAIL_API_KEY")
+ if (!url || !key) return
+ await fetch(url, { method: "POST", headers: { "Authorization": `Bearer ${key}`, "Content-Type": "application/json" }, body: JSON.stringify({ to, subject: "Case Draft", text: link }) })
+}
+
+async function sendWhatsAppMessage(to: string, link: string) {
+ const token = Deno.env.get("WHATSAPP_TOKEN")
+ const phone = Deno.env.get("WHATSAPP_PHONE_ID")
+ if (!token || !phone) return
+ await fetch(`https://graph.facebook.com/v17.0/${phone}/messages`, { method: "POST", headers: { "Authorization": `Bearer ${token}`, "Content-Type": "application/json" }, body: JSON.stringify({ messaging_product: "whatsapp", to, type: "text", text: { body: link } }) })
+}

--- a/supabase/migrations/20250902080000_add_case_invite_columns.sql
+++ b/supabase/migrations/20250902080000_add_case_invite_columns.sql
@@ -1,0 +1,2 @@
+ALTER TABLE public.cases ADD COLUMN case_number TEXT UNIQUE;
+ALTER TABLE public.cases ADD COLUMN invite_token TEXT;


### PR DESCRIPTION
## Summary
- add createCaseDraft edge function to store draft cases and send invite links
- create defendant intake page loading draft via token
- extend cases schema with case_number and invite_token columns

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any...)*

------
https://chatgpt.com/codex/tasks/task_e_68a039fb8b808323b8962203495bc1d5